### PR TITLE
FAI-1102 ACS Search Bug Fix

### DIFF
--- a/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchHelper.cs
+++ b/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchHelper.cs
@@ -88,7 +88,7 @@ public class AzureSearchHelper : IAzureSearchHelper
     {
         if (string.IsNullOrEmpty(searchTerm)) { return "*"; }
 
-        var alphaRegex = new Regex("[a-zA-Z0-9 ]");
+        var alphaRegex = new Regex("[a-zA-Z0-9 ]", RegexOptions.None, TimeSpan.FromMilliseconds(1000));
         var illegalChars = searchTerm.Where(x => !alphaRegex.IsMatch(x.ToString())).ToList();
 
         while (illegalChars.Contains(searchTerm[0]))

--- a/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchHelper.cs
+++ b/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchHelper.cs
@@ -59,12 +59,12 @@ public class AzureSearchHelper : IAzureSearchHelper
 
         if (findVacanciesModel.Lat.HasValue && findVacanciesModel.Lon.HasValue)
         {
-            result.ForEach(c=>c.SearchGeoPoint = new GeoPoint{Lat= findVacanciesModel.Lat.Value, Lon = findVacanciesModel.Lon.Value});
+            result.ForEach(c => c.SearchGeoPoint = new GeoPoint { Lat = findVacanciesModel.Lat.Value, Lon = findVacanciesModel.Lon.Value });
         }
 
         return new ApprenticeshipSearchResponse
         {
-            ApprenticeshipVacancies = result.Select(c=>c)
+            ApprenticeshipVacancies = result.Select(c => c)
                 .ToList(),
             TotalFound = Convert.ToInt32(searchResults.Value.TotalCount),
             Total = Convert.ToInt32(totalVacanciesCount)
@@ -88,14 +88,16 @@ public class AzureSearchHelper : IAzureSearchHelper
     {
         if (string.IsNullOrEmpty(searchTerm)) { return "*"; }
 
-        var alphaRegex = new Regex("[a-zA-Z ]");
+        var alphaRegex = new Regex("[a-zA-Z0-9 ]");
         var illegalChars = searchTerm.Where(x => !alphaRegex.IsMatch(x.ToString())).ToList();
-        foreach (var character in searchTerm)
+
+        while (illegalChars.Contains(searchTerm[0]))
         {
-            if (illegalChars.Contains(character))
-            {
-                searchTerm = searchTerm.Replace($"{character}", string.Empty);
-            }
+            searchTerm = searchTerm.Substring(1);
+        }
+        while (illegalChars.Contains(searchTerm[searchTerm.Length - 1]))
+        {
+            searchTerm = searchTerm.Substring(0, searchTerm.Length - 1);
         }
         return string.IsNullOrEmpty(searchTerm) ? "*" : $"\"{searchTerm}*\"";
     }

--- a/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchHelper.cs
+++ b/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchHelper.cs
@@ -45,7 +45,7 @@ public class AzureSearchHelper : IAzureSearchHelper
             .BuildSearch(findVacanciesModel);
         searchOptions.IncludeTotalCount = true;
 
-        var searchResultsTask = _searchClient.SearchAsync<SearchDocument>($"{findVacanciesModel.SearchTerm}*", searchOptions);
+        var searchResultsTask = _searchClient.SearchAsync<SearchDocument>($"\"{findVacanciesModel.SearchTerm}*\"", searchOptions);
         var totalVacanciesCountTask = _searchClient.GetDocumentCountAsync();
 
         await Task.WhenAll(searchResultsTask, totalVacanciesCountTask);


### PR DESCRIPTION
This PR contains fixes for the following:

- searches in the `'what'` field that are made of two+ words, for example 'delivery manager', being searched for separately. This will now be a phrase query where the full input is searched for as one.
- special chars at the beginning/end of the input string that broke acs. Any special chars (or char not in a-z, A-Z, or 0-9) at beginning/end of input will now be removed from the input string before search