### PR TITLE
FAI-1163 Filter Vacancies

### DIFF
--- a/src/SFA.DAS.FAA.Api.UnitTests/ApiResponses/WhenCastingToGetApprenticeshipVacancyDetailResponse.cs
+++ b/src/SFA.DAS.FAA.Api.UnitTests/ApiResponses/WhenCastingToGetApprenticeshipVacancyDetailResponse.cs
@@ -24,6 +24,7 @@ namespace SFA.DAS.FAA.Api.UnitTests.ApiResponses
                 .Excluding(c=>c.Course)
                 .Excluding(c => c.TypicalJobTitles)
                 .Excluding(c=>c.SearchGeoPoint)
+                .Excluding(c => c.VacancySource)
             );
         }
         [Test, AutoData]
@@ -52,6 +53,7 @@ namespace SFA.DAS.FAA.Api.UnitTests.ApiResponses
                 .Excluding(c=>c.TypicalJobTitles)
                 .Excluding(c => c.WageUnit)
                 .Excluding(c=>c.SearchGeoPoint)
+                .Excluding(c => c.VacancySource)
             );
             response.StandardTitle.Should().Be(source.Course.Title);
             response.Category.Should().Be(source.Course.Title);
@@ -93,6 +95,7 @@ namespace SFA.DAS.FAA.Api.UnitTests.ApiResponses
                 .Excluding(c=>c.SearchGeoPoint)
                 .Excluding(c=>c.Distance)
                 .Excluding(c => c.TypicalJobTitles)
+                .Excluding(c => c.VacancySource)
             );
             response.StandardTitle.Should().Be(source.Course.Title);
             response.Category.Should().Be(source.Course.Title);

--- a/src/SFA.DAS.FAA.Api.UnitTests/ApiResponses/WhenCastingToGetApprenticeshipVacancyResponse.cs
+++ b/src/SFA.DAS.FAA.Api.UnitTests/ApiResponses/WhenCastingToGetApprenticeshipVacancyResponse.cs
@@ -28,6 +28,7 @@ namespace SFA.DAS.FAA.Api.UnitTests.ApiResponses
                 .Excluding(c=>c.SearchGeoPoint)
                 .Excluding(c => c.AdditionalQuestion1)
                 .Excluding(c => c.AdditionalQuestion2)
+                .Excluding(c => c.VacancySource)
             );
             response.ExpectedDuration.Should().Be($"{source.Duration} {(source.Duration == 1 ? source.DurationUnit : $"{source.DurationUnit}s")}");
         }
@@ -66,6 +67,7 @@ namespace SFA.DAS.FAA.Api.UnitTests.ApiResponses
                 .Excluding(c => c.AdditionalQuestion1)
                 .Excluding(c => c.AdditionalQuestion2)
                 .Excluding(c => c.TypicalJobTitles)
+                .Excluding(c => c.VacancySource)
                 );
 
             response.Distance.Should().Be(0);
@@ -106,6 +108,7 @@ namespace SFA.DAS.FAA.Api.UnitTests.ApiResponses
                 .Excluding(c=>c.Distance)
                 .Excluding(c => c.AdditionalQuestion1)
                 .Excluding(c => c.AdditionalQuestion2)
+                .Excluding(c => c.VacancySource)
             );
             response.ExpectedDuration.Should().Be($"{source.Duration} {(source.Duration == 1 ? source.DurationUnit : $"{source.DurationUnit}s")}");
             response.StandardTitle.Should().Be(source.Course.Title);
@@ -154,6 +157,7 @@ namespace SFA.DAS.FAA.Api.UnitTests.ApiResponses
                 .Excluding(c=>c.SearchGeoPoint)
                 .Excluding(c => c.AdditionalQuestion1)
                 .Excluding(c => c.AdditionalQuestion2)
+                .Excluding(c => c.VacancySource)
             );
             response.WageUnit.Should().Be(4);
             response.WageType.Should().Be((int)source.Wage.WageType);

--- a/src/SFA.DAS.FAA.Api/ApiResponses/GetApprenticeshipVacancyResponse.cs
+++ b/src/SFA.DAS.FAA.Api/ApiResponses/GetApprenticeshipVacancyResponse.cs
@@ -58,6 +58,7 @@ namespace SFA.DAS.FAA.Api.ApiResponses
         public string StandardTitle { get; set; }
         public string ApplicationMethod { get; set; }
         public string ApplicationUrl { get; set; }
+        public string VacancySource { get; set; }
 
         public static implicit operator GetApprenticeshipVacancyResponse(ApprenticeshipSearchItem source)
         {
@@ -120,7 +121,8 @@ namespace SFA.DAS.FAA.Api.ApiResponses
                 ProviderContactPhone = source.ProviderContactPhone,
                 Address = source.Address,
                 ApplicationMethod = source.ApplicationMethod,
-                ApplicationUrl = source.ApplicationUrl
+                ApplicationUrl = source.ApplicationUrl,
+                VacancySource = source.VacancySource
             };
         }
 

--- a/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchHelper.cs
+++ b/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchHelper.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Azure;
 using Azure.Core.Serialization;
 using Azure.Identity;
 using Azure.Search.Documents;

--- a/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchOptionExtensions.cs
+++ b/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchOptionExtensions.cs
@@ -75,7 +75,7 @@ public static class AzureSearchOptionExtensions
 
     public static SearchOptions BuildFilters(this SearchOptions searchOptions, FindVacanciesModel findVacanciesModel)
     {
-        List<string> searchFilters = new();
+        List<string> searchFilters = new() { "VacancySource eq 'RAA'" };
 
         if (findVacanciesModel.Ukprn.HasValue)
         {
@@ -136,13 +136,13 @@ public static class AzureSearchOptionExtensions
             searchFilters.Add($"PostedDate ge {DateTime.UtcNow.AddDays(-numberOfDays)}");
         }
 
-        if(findVacanciesModel.DisabilityConfident != false)
+        if (findVacanciesModel.DisabilityConfident != false)
         {
             searchFilters.Add("IsDisabilityConfident eq true");
         }
 
         searchOptions.Filter = string.Join(" and ", searchFilters.ToArray());
-      
+
         return searchOptions;
     }
 

--- a/src/SFA.DAS.FAA.Domain/Entities/ApprenticeshipSearchItem.cs
+++ b/src/SFA.DAS.FAA.Domain/Entities/ApprenticeshipSearchItem.cs
@@ -62,6 +62,7 @@ namespace SFA.DAS.FAA.Domain.Entities
         public string ApplicationUrl { get; set; }
         public string AdditionalQuestion1 { get; set; }
         public string AdditionalQuestion2 { get; set; }
+        public string VacancySource { get; set; }
     }
     
     


### PR DESCRIPTION
Changes include adding a filter to the acs search so that it only returns vacancies sourced from RAA (not NHS).