### PR TITLE
DASD-11101 Add dedicated ASP

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -48,6 +48,12 @@
         "keyVaultCertificateName": {
             "type": "string"
         },
+        "sharedBackEndAppServicePlanName": {
+            "type": "string"
+        },
+        "sharedBackEndSubnetResourceId": {
+            "type": "string"
+        },
         "backEndAccessRestrictions": {
             "type": "array"
         },
@@ -229,13 +235,13 @@
                         "value": "[variables('apiAppServiceName')]"
                     },
                     "appServicePlanName": {
-                        "value": "[variables('appServicePlanName')]"
+                        "value": "[parameters('sharedBackEndAppServicePlanName')]"
                     },
                     "appServicePlanResourceGroup": {
                         "value": "[parameters('sharedEnvResourceGroup')]"
                     },
                     "subnetResourceId": {
-                        "value": "[reference(concat(parameters('subnetObject').name, '-', parameters('utcValue'))).outputs.subnetResourceId.value]"
+                        "value": "[parameters('sharedBackEndSubnetResourceId')]"
                     },
                     "appServiceAppSettings": {
                         "value": {

--- a/azure/template.json
+++ b/azure/template.json
@@ -75,6 +75,10 @@
             "type": "int",
             "defaultValue": 1
         },
+        "nonASETier": {
+            "type": "string",
+            "defaultValue": "PremiumV2"
+        },
         "sharedEnvVirtualNetworkName": {
             "type": "string"
         },
@@ -158,6 +162,9 @@
                     },
                     "aspInstances": {
                         "value": "[parameters('aspInstances')]"
+                    },
+                    "nonASETier": {
+                        "value": "[parameters('nonASETier')]"
                     }
                 }
             },

--- a/azure/template.json
+++ b/azure/template.json
@@ -51,17 +51,14 @@
         "backEndAccessRestrictions": {
             "type": "array"
         },
+        "sharedAiSearchName": {
+            "type": "string"
+        },
         "utcValue": {
             "type": "string",
             "defaultValue": "[utcNow()]"
         },
         "tenant": {
-            "type": "string"
-        },
-        "azureSearchResourceGroup": {
-            "type": "string"
-        },
-        "azureSearchName": {
             "type": "string"
         },
         "aspSize": {
@@ -296,6 +293,30 @@
             "dependsOn": [
                 "[concat(variables('apiAppServiceName'), '-app-service-plan-', parameters('utcValue'))]"
             ]
+        },
+        {
+            "apiVersion": "2021-04-01",
+            "name": "[concat('role-assignment-', variables('apiAppServiceName'), '-', parameters('utcValue'))]",
+            "type": "Microsoft.Resources/deployments",
+            "resourceGroup": "[parameters('sharedEnvResourceGroup')]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'role-assignments/role-assignment-ai-search.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "principalId": {
+                        "value": "[reference(concat(variables('apiAppServiceName'), '-', parameters('utcValue'))).outputs.managedServiceIdentityId.value]"
+                    },
+                    "assignmentType": {
+                        "value": "SearchIndexDataReader"
+                    },
+                    "resourceName": {
+                        "value": "[parameters('sharedAiSearchName')]"
+                    }
+                }
+            }
         }
     ],
     "outputs": {
@@ -306,18 +327,6 @@
         "ApiAppServiceName": {
             "type": "string",
             "value": "[variables('apiAppServiceName')]"
-        },
-        "AzureSearchResource": {
-            "type": "string",
-            "value": "[concat('https://', parameters('tenant'), '/', parameters('azureSearchName'))]"
-        },
-        "AzureSearchBaseUrl": {
-            "type": "string",
-            "value": "[concat('https://', parameters('azureSearchName'), '.search.windows.net')]"
-        },
-        "AzureSearchQueryKey": {
-            "type": "string",
-            "value": "[listQueryKeys(resourceId(parameters('logAnalyticsSubscriptionId'), parameters('azureSearchResourceGroup'), 'Microsoft.Search/searchServices', parameters('azureSearchName')), '2015-08-19').value[0].key]"
         }
     }
 }

--- a/azure/template.json
+++ b/azure/template.json
@@ -48,17 +48,8 @@
         "keyVaultCertificateName": {
             "type": "string"
         },
-        "sharedBackEndAppServicePlanName": {
-            "type": "string"
-        },
-        "sharedBackEndSubnetResourceId": {
-            "type": "string"
-        },
         "backEndAccessRestrictions": {
             "type": "array"
-        },
-        "sharedAiSearchName": {
-            "type": "string"
         },
         "utcValue": {
             "type": "string",
@@ -66,6 +57,32 @@
         },
         "tenant": {
             "type": "string"
+        },
+        "azureSearchResourceGroup": {
+            "type": "string"
+        },
+        "azureSearchName": {
+            "type": "string"
+        },
+        "aspSize": {
+            "type": "string",
+            "defaultValue": "1"
+        },
+        "aspInstances": {
+            "type": "int",
+            "defaultValue": 1
+        },
+        "sharedEnvVirtualNetworkName": {
+            "type": "string"
+        },
+        "subnetObject": {
+            "type": "object"
+        },
+        "subnetServiceEndpointList": {
+            "type": "array"
+        },
+        "subnetDelegations": {
+            "type": "array"
         }
     },
     "variables": {
@@ -73,6 +90,7 @@
         "resourceNamePrefix": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
         "resourceGroupName": "[concat(variables('resourceNamePrefix'), '-rg')]",
         "apiAppServiceName": "[concat(variables('resourceNamePrefix'), '-as')]",
+        "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-asp')]",
         "configNames": "SFA.DAS.FindApprenticeships.Api"
     },
     "resources": [
@@ -83,6 +101,66 @@
             "location": "[parameters('resourceGroupLocation')]",
             "tags": "[parameters('tags')]",
             "properties": {}
+        },
+        {
+            "apiVersion": "2021-04-01",
+            "name": "[concat(parameters('subnetObject').name, '-', parameters('utcValue'))]",
+            "type": "Microsoft.Resources/deployments",
+            "resourceGroup": "[parameters('sharedEnvResourceGroup')]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'subnet.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "virtualNetworkName": {
+                        "value": "[parameters('sharedEnvVirtualNetworkName')]"
+                    },
+                    "subnetName": {
+                        "value": "[parameters('subnetObject').name]"
+                    },
+                    "subnetAddressPrefix": {
+                        "value": "[parameters('subnetObject').addressSpace]"
+                    },
+                    "serviceEndpointList": {
+                        "value": "[parameters('subnetServiceEndpointList')]"
+                    },
+                    "delegations": {
+                        "value": "[parameters('subnetDelegations')]"
+                    }
+                }
+            },
+            "dependsOn": [
+                "[variables('resourceGroupName')]"
+            ]
+        },
+        {
+            "apiVersion": "2021-04-01",
+            "name": "[concat(variables('apiAppServiceName'), '-app-service-plan-', parameters('utcValue'))]",
+            "type": "Microsoft.Resources/deployments",
+            "resourceGroup": "[parameters('sharedEnvResourceGroup')]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'app-service-plan.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "appServicePlanName": {
+                        "value": "[variables('appServicePlanName')]"
+                    },
+                    "aspSize": {
+                        "value": "[parameters('aspSize')]"
+                    },
+                    "aspInstances": {
+                        "value": "[parameters('aspInstances')]"
+                    }
+                }
+            },
+            "dependsOn": [
+                "[variables('resourceGroupName')]"
+            ]
         },
         {
             "apiVersion": "2021-04-01",
@@ -154,13 +232,13 @@
                         "value": "[variables('apiAppServiceName')]"
                     },
                     "appServicePlanName": {
-                        "value": "[parameters('sharedBackEndAppServicePlanName')]"
+                        "value": "[variables('appServicePlanName')]"
                     },
                     "appServicePlanResourceGroup": {
                         "value": "[parameters('sharedEnvResourceGroup')]"
                     },
                     "subnetResourceId": {
-                        "value": "[parameters('sharedBackEndSubnetResourceId')]"
+                        "value": "[reference(concat(parameters('subnetObject').name, '-', parameters('utcValue'))).outputs.subnetResourceId.value]"
                     },
                     "appServiceAppSettings": {
                         "value": {
@@ -214,31 +292,10 @@
                         "value": "[parameters('backEndAccessRestrictions')]"
                     }
                 }
-            }
-        },
-        {
-            "apiVersion": "2021-04-01",
-            "name": "[concat('role-assignment-', variables('apiAppServiceName'), '-', parameters('utcValue'))]",
-            "type": "Microsoft.Resources/deployments",
-            "resourceGroup": "[parameters('sharedEnvResourceGroup')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(variables('deploymentUrlBase'),'role-assignments/role-assignment-ai-search.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "principalId": {
-                        "value": "[reference(concat(variables('apiAppServiceName'), '-', parameters('utcValue'))).outputs.managedServiceIdentityId.value]"
-                    },
-                    "assignmentType": {
-                        "value": "SearchIndexDataReader"
-                    },
-                    "resourceName": {
-                        "value": "[parameters('sharedAiSearchName')]"
-                    }
-                }
-            }
+            },
+            "dependsOn": [
+                "[concat(variables('apiAppServiceName'), '-app-service-plan-', parameters('utcValue'))]"
+            ]
         }
     ],
     "outputs": {
@@ -249,6 +306,18 @@
         "ApiAppServiceName": {
             "type": "string",
             "value": "[variables('apiAppServiceName')]"
+        },
+        "AzureSearchResource": {
+            "type": "string",
+            "value": "[concat('https://', parameters('tenant'), '/', parameters('azureSearchName'))]"
+        },
+        "AzureSearchBaseUrl": {
+            "type": "string",
+            "value": "[concat('https://', parameters('azureSearchName'), '.search.windows.net')]"
+        },
+        "AzureSearchQueryKey": {
+            "type": "string",
+            "value": "[listQueryKeys(resourceId(parameters('logAnalyticsSubscriptionId'), parameters('azureSearchResourceGroup'), 'Microsoft.Search/searchServices', parameters('azureSearchName')), '2015-08-19').value[0].key]"
         }
     }
 }


### PR DESCRIPTION
**Context**

The API will see increased load when the FAA v2 UI goes live. We should move the app on to it's own ASP for go-live and then hopefully back on to one of the new shared ASP's when they are deployed.

The move has a number of phases.

1. This PR creates the ASP and subnet for the change.
2. A script can then be run that disconnects the subnet, moves the app to the new ASP and reconnects to the new subnet
3. Follow-up PR to align the ARM template to the new structure

**Proposed changes**

1. Add new ASP resource
2. Add new subnet resource