### PR TITLE
FAI-2225 Adding RouteId as part of Query Filter to Search the vacancies & Count endpoints

### DIFF
--- a/src/SFA.DAS.FAA.Api.UnitTests/Controllers/VacanciesV2/WhenGettingVacancySearch.cs
+++ b/src/SFA.DAS.FAA.Api.UnitTests/Controllers/VacanciesV2/WhenGettingVacancySearch.cs
@@ -35,7 +35,6 @@ public class WhenGettingVacancySearch
                     query.DistanceInMiles == request.DistanceInMiles &&
                     query.Categories == request.Categories &&
                     query.RouteIds == request.RouteIds &&
-                    query.RouteIds == request.RouteIds &&
                     query.Levels == request.Levels &&
                     query.PostedInLastNumberOfDays == request.PostedInLastNumberOfDays &&
                     query.VacancySort.Equals(request.Sort) &&

--- a/src/SFA.DAS.FAA.Api.UnitTests/Controllers/VacanciesV2/WhenGettingVacancySearch.cs
+++ b/src/SFA.DAS.FAA.Api.UnitTests/Controllers/VacanciesV2/WhenGettingVacancySearch.cs
@@ -1,18 +1,13 @@
-﻿using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
-using AutoFixture.NUnit3;
-using FluentAssertions;
-using MediatR;
+﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using Moq;
-using NUnit.Framework;
 using SFA.DAS.FAA.Api.ApiRequests;
 using SFA.DAS.FAA.Api.ApiResponses;
 using SFA.DAS.FAA.Api.Controllers;
 using SFA.DAS.FAA.Application.Vacancies.Queries.SearchApprenticeshipVacancies;
 using SFA.DAS.FAA.Domain.Models;
-using SFA.DAS.Testing.AutoFixture;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace SFA.DAS.FAA.Api.UnitTests.Controllers.VacanciesV2;
 public class WhenGettingVacancySearch
@@ -39,6 +34,8 @@ public class WhenGettingVacancySearch
                     query.Lon.Equals(request.Lon) &&
                     query.DistanceInMiles == request.DistanceInMiles &&
                     query.Categories == request.Categories &&
+                    query.RouteIds == request.RouteIds &&
+                    query.RouteIds == request.RouteIds &&
                     query.Levels == request.Levels &&
                     query.PostedInLastNumberOfDays == request.PostedInLastNumberOfDays &&
                     query.VacancySort.Equals(request.Sort) &&

--- a/src/SFA.DAS.FAA.Api/ApiRequests/SearchVacancyRequest.cs
+++ b/src/SFA.DAS.FAA.Api/ApiRequests/SearchVacancyRequest.cs
@@ -32,6 +32,8 @@ public class SearchVacancyRequest
     [FromQuery] [ModelBinder(typeof(NonNullListStringModelBinder))]
     public List<string> Categories  { get; set; } = null;
     [FromQuery]
+    public List<int> RouteIds { get; set; } = null;
+    [FromQuery]
     [ModelBinder(typeof(NonNullListStringModelBinder))]
     public List<string> Levels { get; set; } = null;
     [FromQuery]

--- a/src/SFA.DAS.FAA.Api/ApiRequests/SearchVacancyTotalRequest.cs
+++ b/src/SFA.DAS.FAA.Api/ApiRequests/SearchVacancyTotalRequest.cs
@@ -21,6 +21,8 @@ public class SearchVacancyTotalRequest
     [ModelBinder(typeof(NonNullListStringModelBinder))]
     public List<string> Categories { get; set; } = null;
     [FromQuery]
+    public List<int> RouteIds { get; set; } = null;
+    [FromQuery]
     [ModelBinder(typeof(NonNullListStringModelBinder))]
     public List<string> Levels { get; set; } = null;
     [FromQuery]

--- a/src/SFA.DAS.FAA.Api/Controllers/VacanciesController.cs
+++ b/src/SFA.DAS.FAA.Api/Controllers/VacanciesController.cs
@@ -67,6 +67,7 @@ namespace SFA.DAS.FAA.Api.Controllers
                     AccountPublicHashedId = request.AccountPublicHashedId,
                     AccountLegalEntityPublicHashedId = request.AccountLegalEntityPublicHashedId,
                     Categories = request.Categories,
+                    RouteIds = request.RouteIds,
                     Levels = request.Levels,
                     Lat = request.Lat,
                     Lon = request.Lon,
@@ -101,6 +102,7 @@ namespace SFA.DAS.FAA.Api.Controllers
                 {
                     SearchTerm = request.SearchTerm,
                     Categories = request.Categories,
+                    RouteIds = request.RouteIds,
                     Levels = request.Levels,
                     Lat = request.Lat,
                     Lon = request.Lon,

--- a/src/SFA.DAS.FAA.Application/Vacancies/Queries/GetApprenticeshipVacancyCount/GetApprenticeshipVacancyCountQuery.cs
+++ b/src/SFA.DAS.FAA.Application/Vacancies/Queries/GetApprenticeshipVacancyCount/GetApprenticeshipVacancyCountQuery.cs
@@ -10,6 +10,7 @@ namespace SFA.DAS.FAA.Application.Vacancies.Queries.GetApprenticeshipVacancyCoun
         public bool? NationWideOnly { get; init; }
         public uint? DistanceInMiles { get; init; }
         public List<string> Categories { get; init; }
+        public List<int> RouteIds { get; init; }
         public List<string> Levels { get; init; }
         public double? Lat { get; init; }
         public double? Lon { get; init; }

--- a/src/SFA.DAS.FAA.Application/Vacancies/Queries/GetApprenticeshipVacancyCount/GetApprenticeshipVacancyCountQueryHandler.cs
+++ b/src/SFA.DAS.FAA.Application/Vacancies/Queries/GetApprenticeshipVacancyCount/GetApprenticeshipVacancyCountQueryHandler.cs
@@ -15,6 +15,7 @@ namespace SFA.DAS.FAA.Application.Vacancies.Queries.GetApprenticeshipVacancyCoun
             {
                 SearchTerm = request.SearchTerm,
                 Categories = request.Categories,
+                RouteIds = request.RouteIds,
                 Lat = request.Lat,
                 Lon = request.Lon,
                 DistanceInMiles = request.DistanceInMiles,

--- a/src/SFA.DAS.FAA.Application/Vacancies/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesQuery.cs
+++ b/src/SFA.DAS.FAA.Application/Vacancies/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesQuery.cs
@@ -17,6 +17,7 @@ namespace SFA.DAS.FAA.Application.Vacancies.Queries.SearchApprenticeshipVacancie
         public uint? DistanceInMiles { get ; init ; }
         public uint? PostedInLastNumberOfDays { get ; init ; }
         public List<string> Categories { get ; init ; }
+        public List<int> RouteIds { get; init; }
         public List<string> Levels { get; init; }
         public double? Lat { get ; init ; }
         public double? Lon { get ; init ; }

--- a/src/SFA.DAS.FAA.Application/Vacancies/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesQueryHandler.cs
+++ b/src/SFA.DAS.FAA.Application/Vacancies/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesQueryHandler.cs
@@ -21,6 +21,7 @@ namespace SFA.DAS.FAA.Application.Vacancies.Queries.SearchApprenticeshipVacancie
                 AccountLegalEntityPublicHashedId = request.AccountLegalEntityPublicHashedId,
                 StandardLarsCode = request.StandardLarsCode,
                 Categories = request.Categories,
+                RouteIds = request.RouteIds,
                 Lat = request.Lat,
                 Lon = request.Lon,
                 DistanceInMiles = request.DistanceInMiles,

--- a/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchOptionExtensions.cs
+++ b/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchOptionExtensions.cs
@@ -181,6 +181,13 @@ public static class AzureSearchOptionExtensions
             searchFilters.Add($"({string.Join(" or ", [.. categoryClauses])})");
         }
 
+        if (findVacanciesModel.RouteIds is { Count: not 0 })
+        {
+            var routeIdClauses = new List<string>();
+            findVacanciesModel.RouteIds.ForEach(route => routeIdClauses.Add($"Course/RouteCode eq {route}"));
+            searchFilters.Add($"({string.Join(" or ", [.. routeIdClauses])})");
+        }
+
         if (findVacanciesModel.Levels != null && findVacanciesModel.Levels.Count != 0)
         {
             var levelClauses = new List<string>();
@@ -251,6 +258,13 @@ public static class AzureSearchOptionExtensions
             var categoryClauses = new List<string>();
             findVacanciesModel.Categories.ForEach(category => categoryClauses.Add($"Route eq '{category}'"));
             searchFilters.Add($"({string.Join(" or ", [.. categoryClauses])})");
+        }
+
+        if (findVacanciesModel.RouteIds is { Count: not 0 })
+        {
+            var routeIdClauses = new List<string>();
+            findVacanciesModel.RouteIds.ForEach(route => routeIdClauses.Add($"Course/RouteCode eq {route}"));
+            searchFilters.Add($"({string.Join(" or ", [.. routeIdClauses])})");
         }
 
         if (findVacanciesModel.Levels != null && findVacanciesModel.Levels.Count != 0)

--- a/src/SFA.DAS.FAA.Domain/Models/FindVacanciesCountModel.cs
+++ b/src/SFA.DAS.FAA.Domain/Models/FindVacanciesCountModel.cs
@@ -7,6 +7,7 @@ namespace SFA.DAS.FAA.Domain.Models
         public string? SearchTerm { get; init; }
         public int? Ukprn { get; init; }
         public List<string> Categories { get; set; }
+        public List<int> RouteIds { get; set; }
         public List<string> Levels { get; init; }
         public bool DisabilityConfident { get; set; }
         public WageType? WageType { get; set; }

--- a/src/SFA.DAS.FAA.Domain/Models/FindVacanciesModel.cs
+++ b/src/SFA.DAS.FAA.Domain/Models/FindVacanciesModel.cs
@@ -12,6 +12,7 @@ namespace SFA.DAS.FAA.Domain.Models
         public string AccountLegalEntityPublicHashedId { get; init; }
         public List<int> StandardLarsCode { get; set; }
         public List<string> Categories { get; set; }
+        public List<int> RouteIds { get; set; }
         public List<string> Levels { get; init; }
         public uint? PostedInLastNumberOfDays { get; set; }
         public VacancySort VacancySort { get; set; }


### PR DESCRIPTION
- Implemented a unit test to verify that the Search method in VacanciesController correctly retrieves search results from the mediator.
- Verified that the controller returns an OkObjectResult with the expected status code and response model.

This change ensures that the Search method behaves as expected when called with a valid SearchVacancyRequest.