### PR TITLE
FAI-2232 Enhance null safety in apprenticeship vacancy models

### DIFF
--- a/src/SFA.DAS.FAA.Api/ApiResponses/GetApprenticeshipVacanciesByReferenceApiResponse.cs
+++ b/src/SFA.DAS.FAA.Api/ApiResponses/GetApprenticeshipVacanciesByReferenceApiResponse.cs
@@ -18,7 +18,7 @@ namespace SFA.DAS.FAA.Api.ApiResponses
             public string ApplicationUrl { get; set; }
             public bool IsPrimaryLocation { get; set; }
             public Address Address { get; set; }
-            public List<Address> OtherAddresses { get; set; }
+            public List<Address>? OtherAddresses { get; set; } = [];
             public string? EmploymentLocationInformation { get; set; }
             public string? AvailableWhere { get; set; }
         }
@@ -33,6 +33,8 @@ namespace SFA.DAS.FAA.Api.ApiResponses
 
             public static implicit operator Address(GetApprenticeshipVacanciesByReferenceQueryResult.Address source)
             {
+                if (source is null) return null;
+
                 return new Address
                 {
                     AddressLine1 = source.AddressLine1,
@@ -56,7 +58,7 @@ namespace SFA.DAS.FAA.Api.ApiResponses
                     Title = x.Title,
                     ClosingDate = x.ClosingDate,
                     ApplicationUrl = x.ApplicationUrl,
-                    OtherAddresses = x.OtherAddresses.Select(add => (Address)add).ToList(),
+                    OtherAddresses = x.OtherAddresses?.Select(add => (Address)add).ToList(),
                     Address = x.Address,
                     IsPrimaryLocation = x.IsPrimaryLocation,
                     AvailableWhere = x.AvailableWhere,

--- a/src/SFA.DAS.FAA.Application/Vacancies/Queries/GetApprenticeshipsVacanciesByIdList/GetApprenticeshipVacanciesByReferenceQuery.cs
+++ b/src/SFA.DAS.FAA.Application/Vacancies/Queries/GetApprenticeshipsVacanciesByIdList/GetApprenticeshipVacanciesByReferenceQuery.cs
@@ -26,7 +26,7 @@ namespace SFA.DAS.FAA.Application.Vacancies.Queries.GetApprenticeshipsVacanciesB
             public string ApplicationUrl { get; set; }
             public bool IsPrimaryLocation { get; set; }
             public Address Address { get; set; }
-            public List<Address>? OtherAddresses { get; set; }
+            public List<Address>? OtherAddresses { get; set; } = [];
             public string? EmploymentLocationInformation { get; set; }
             public string? AvailableWhere { get; set; }
         }
@@ -41,6 +41,8 @@ namespace SFA.DAS.FAA.Application.Vacancies.Queries.GetApprenticeshipsVacanciesB
 
             public static implicit operator Address(Domain.Entities.Address source)
             {
+                if (source is null) return null;
+
                 return new Address
                 {
                     AddressLine4 = source.AddressLine4,


### PR DESCRIPTION
- Updated `OtherAddresses` property to support nullability and initialized to an empty list to prevent null reference exceptions.
- Added null check in the implicit operator for the `Address` class to return null if the source is null.
- Utilized the null-conditional operator when selecting `OtherAddresses` for safer navigation.