### PR TITLE
FAI-2366 Display advert api v2

### DIFF
--- a/src/SFA.DAS.FAA.Api.UnitTests/Controllers/VacanciesV2/WhenGettingVacancySearch.cs
+++ b/src/SFA.DAS.FAA.Api.UnitTests/Controllers/VacanciesV2/WhenGettingVacancySearch.cs
@@ -28,6 +28,7 @@ public class WhenGettingVacancySearch
                     query.Ukprn == request.Ukprn &&
                     query.AccountPublicHashedId == request.AccountPublicHashedId &&
                     query.AccountLegalEntityPublicHashedId == request.AccountLegalEntityPublicHashedId &&
+                    query.EmployerName == request.EmployerName &&
                     query.StandardLarsCode == request.StandardLarsCode &&
                     query.ExcludeNational == request.ExcludeNational &&
                     query.Lat.Equals(request.Lat) &&

--- a/src/SFA.DAS.FAA.Api/ApiRequests/SearchVacancyRequest.cs
+++ b/src/SFA.DAS.FAA.Api/ApiRequests/SearchVacancyRequest.cs
@@ -20,6 +20,8 @@ public class SearchVacancyRequest
     [FromQuery]
     public string AccountLegalEntityPublicHashedId  { get; set; } = null;
     [FromQuery]
+    public string EmployerName { get; set; } = null;
+    [FromQuery]
     public List<int> StandardLarsCode  { get; set; } = null;
     [FromQuery]
     public bool? ExcludeNational  { get; set; } = null;

--- a/src/SFA.DAS.FAA.Api/Controllers/VacanciesController.cs
+++ b/src/SFA.DAS.FAA.Api/Controllers/VacanciesController.cs
@@ -66,6 +66,7 @@ namespace SFA.DAS.FAA.Api.Controllers
                     Ukprn = request.Ukprn,
                     AccountPublicHashedId = request.AccountPublicHashedId,
                     AccountLegalEntityPublicHashedId = request.AccountLegalEntityPublicHashedId,
+                    EmployerName = request.EmployerName,
                     Categories = request.Categories,
                     RouteIds = request.RouteIds,
                     Levels = request.Levels,

--- a/src/SFA.DAS.FAA.Application.UnitTests/Vacancies/Queries/WhenSearchingApprenticeshipVacancies.cs
+++ b/src/SFA.DAS.FAA.Application.UnitTests/Vacancies/Queries/WhenSearchingApprenticeshipVacancies.cs
@@ -23,6 +23,7 @@ namespace SFA.DAS.FAA.Application.UnitTests.Vacancies.Queries
                         c.Ukprn.Equals(query.Ukprn) &&
                         c.AccountPublicHashedId.Equals(query.AccountPublicHashedId) &&
                         c.AccountLegalEntityPublicHashedId.Equals(query.AccountLegalEntityPublicHashedId) &&
+                        c.EmployerName.Equals(query.EmployerName) &&
                         c.StandardLarsCode.Equals(query.StandardLarsCode) &&
                         c.Categories.Equals(query.Categories) &&
                         c.Levels.Equals(query.Levels) &&

--- a/src/SFA.DAS.FAA.Application/Vacancies/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesQuery.cs
+++ b/src/SFA.DAS.FAA.Application/Vacancies/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesQuery.cs
@@ -12,6 +12,7 @@ namespace SFA.DAS.FAA.Application.Vacancies.Queries.SearchApprenticeshipVacancie
         public int? Ukprn { get; init; }
         public string AccountPublicHashedId { get; init; }
         public string AccountLegalEntityPublicHashedId { get ; init ; }
+        public string EmployerName { get; init; }
         public List<int> StandardLarsCode { get ; init ; }
         public bool? ExcludeNational { get ; init ; }
         public uint? DistanceInMiles { get ; init ; }

--- a/src/SFA.DAS.FAA.Application/Vacancies/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesQueryHandler.cs
+++ b/src/SFA.DAS.FAA.Application/Vacancies/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesQueryHandler.cs
@@ -15,6 +15,7 @@ namespace SFA.DAS.FAA.Application.Vacancies.Queries.SearchApprenticeshipVacancie
             {
                 AccountLegalEntityPublicHashedId = request.AccountLegalEntityPublicHashedId,
                 AccountPublicHashedId = request.AccountPublicHashedId,
+                EmployerName = request.EmployerName,
                 AdditionalDataSources = request.AdditionalDataSources,
                 Categories = request.Categories,
                 DisabilityConfident = request.DisabilityConfident,

--- a/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchOptionExtensions.cs
+++ b/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchOptionExtensions.cs
@@ -169,6 +169,11 @@ public static class AzureSearchOptionExtensions
             searchFilters.Add($"AccountLegalEntityPublicHashedId eq '{findVacanciesModel.AccountLegalEntityPublicHashedId}'");
         }
 
+        if (!string.IsNullOrEmpty(findVacanciesModel.EmployerName))
+        {
+            searchFilters.Add($"EmployerName eq '{findVacanciesModel.EmployerName}'");
+        }
+
         if (findVacanciesModel.StandardLarsCode != null && findVacanciesModel.StandardLarsCode.Count != 0)
         {
             var larsCodeClauses = new List<string>();

--- a/src/SFA.DAS.FAA.Domain/Models/FindVacanciesModel.cs
+++ b/src/SFA.DAS.FAA.Domain/Models/FindVacanciesModel.cs
@@ -10,6 +10,7 @@ namespace SFA.DAS.FAA.Domain.Models
         public int? Ukprn { get; init; }
         public string AccountPublicHashedId { get; init; }
         public string AccountLegalEntityPublicHashedId { get; init; }
+        public string EmployerName { get; init; }
         public List<int> StandardLarsCode { get; set; }
         public List<string> Categories { get; set; }
         public List<int> RouteIds { get; set; }


### PR DESCRIPTION
✨ Add EmployerName filter to vacancy search functionality

- Introduced `EmployerName` property in multiple classes.
- Updated `WhenGettingVacancySearch` to include `EmployerName` in queries.
- Modified `VacanciesController` to map `EmployerName` from requests.
- Enhanced equality checks in `WhenSearchingApprenticeshipVacancies`.
- Added search filter for `EmployerName` in `AzureSearchOptionExtensions`.

Changes made by Balaji Jambulingam