### PR TITLE
FAI-2569 BUG Saved Search Error

### DIFF
--- a/src/SFA.DAS.FAA.Api.UnitTests/Controllers/Users/WhenGettingSavedSearch.cs
+++ b/src/SFA.DAS.FAA.Api.UnitTests/Controllers/Users/WhenGettingSavedSearch.cs
@@ -58,7 +58,29 @@ public class WhenGettingSavedSearch
         // assert
         response.Should().NotBeNull();
     }
-    
+
+
+    [Test, MoqAutoData]
+    public async Task When_SavedSearch_Is_Null_Then_NotFound_Is_Returned(
+        Guid userReference,
+        Guid id,
+        GetUserSavedSearchQueryResult result,
+        [Frozen] Mock<IMediator> mediator,
+        [Greedy] UsersController sut)
+    {
+        // arrange
+        result = new GetUserSavedSearchQueryResult(null);
+        mediator
+            .Setup(x => x.Send(It.IsAny<GetUserSavedSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+
+        // act
+        var response = await sut.Get(userReference, id) as NotFoundResult;
+
+        // assert
+        response.Should().NotBeNull();
+    }
+
     [Test, MoqAutoData]
     public async Task Then_Exceptions_Are_Handled(
         Guid userReference,

--- a/src/SFA.DAS.FAA.Api/ApiResponses/GetSavedSearchesByUserReferenceResponse.cs
+++ b/src/SFA.DAS.FAA.Api/ApiResponses/GetSavedSearchesByUserReferenceResponse.cs
@@ -12,7 +12,10 @@ public class GetSavedSearchesByUserReferenceResponse
     {
         return new GetSavedSearchesByUserReferenceResponse
         {
-            SavedSearches = source.SavedSearches.Select(SavedSearchDto.From).ToList()
+            SavedSearches = source
+                .SavedSearches
+                .Where(x => x.SearchParameters != null)
+                .Select(SavedSearchDto.From).ToList()
         };
     }
 }

--- a/src/SFA.DAS.FAA.Api/ApiResponses/GetSavedSearchesResponse.cs
+++ b/src/SFA.DAS.FAA.Api/ApiResponses/GetSavedSearchesResponse.cs
@@ -18,6 +18,8 @@ public record SavedSearchDto(
     {
         public static SavedSearchDto From(SavedSearch source)
         {
+            if (source?.SearchParameters == null) return null;
+
             return new SavedSearchDto(
                 source.Id,
                 source.UserReference,

--- a/src/SFA.DAS.FAA.Api/Controllers/SavedSearchesController.cs
+++ b/src/SFA.DAS.FAA.Api/Controllers/SavedSearchesController.cs
@@ -49,7 +49,7 @@ public class SavedSearchesController(IMediator mediator, ILogger<SavedSearchesCo
         {
             var result = await mediator.Send(new GetSavedSearchQuery(id));
 
-            if (result.SavedSearch == null)
+            if (result?.SavedSearch?.SearchParameters == null)
             {
                 return NotFound();
             }

--- a/src/SFA.DAS.FAA.Api/Controllers/UsersController.cs
+++ b/src/SFA.DAS.FAA.Api/Controllers/UsersController.cs
@@ -56,7 +56,7 @@ public class UsersController(IMediator mediator, ILogger<SavedSearchesController
         try
         {
             var result = await mediator.Send(new GetUserSavedSearchQuery(userReference, id), cancellationToken);
-            return result is null
+            return result?.SavedSearch is null
                 ? NotFound()
                 : Ok(new GetSavedSearchResponse(SavedSearchDto.From(result.SavedSearch)));
         }

--- a/src/SFA.DAS.FAA.Api/Controllers/UsersController.cs
+++ b/src/SFA.DAS.FAA.Api/Controllers/UsersController.cs
@@ -1,21 +1,19 @@
-using System;
-using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.FAA.Api.ApiRequests;
 using SFA.DAS.FAA.Api.ApiResponses;
-using SFA.DAS.FAA.Application.SavedSearches.Commands.DeleteSavedSearch;
 using SFA.DAS.FAA.Application.SavedSearches.Commands.DeleteSavedSearches;
 using SFA.DAS.FAA.Application.SavedSearches.Commands.DeleteUserSavedSearch;
 using SFA.DAS.FAA.Application.SavedSearches.Commands.UpsertSaveSearch;
-using SFA.DAS.FAA.Application.SavedSearches.Queries.GetSavedSearch;
 using SFA.DAS.FAA.Application.SavedSearches.Queries.GetSavedSearchCount;
 using SFA.DAS.FAA.Application.SavedSearches.Queries.GetSavedSearchesByUserReference;
 using SFA.DAS.FAA.Application.SavedSearches.Queries.GetUserSavedSearch;
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace SFA.DAS.FAA.Api.Controllers;
 
@@ -56,7 +54,7 @@ public class UsersController(IMediator mediator, ILogger<SavedSearchesController
         try
         {
             var result = await mediator.Send(new GetUserSavedSearchQuery(userReference, id), cancellationToken);
-            return result?.SavedSearch is null
+            return result?.SavedSearch?.SearchParameters is null
                 ? NotFound()
                 : Ok(new GetSavedSearchResponse(SavedSearchDto.From(result.SavedSearch)));
         }

--- a/src/SFA.DAS.FAA.Application.UnitTests/Vacancies/Queries/WhenHandlingGetUserSavedSearchQuery.cs
+++ b/src/SFA.DAS.FAA.Application.UnitTests/Vacancies/Queries/WhenHandlingGetUserSavedSearchQuery.cs
@@ -1,0 +1,57 @@
+﻿using SFA.DAS.FAA.Application.SavedSearches.Queries.GetUserSavedSearch;
+using SFA.DAS.FAA.Data.SavedSearch;
+using SFA.DAS.FAA.Domain.Entities;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using SFA.DAS.FAA.Domain.Models;
+
+namespace SFA.DAS.FAA.Application.UnitTests.Vacancies.Queries
+{
+    [TestFixture]
+    internal class WhenHandlingGetUserSavedSearchQuery
+    {
+        [Test, MoqAutoData]
+        public async Task Then_It_Should_Return_Saved_Searches_For_User(
+            GetUserSavedSearchQuery query,
+            SearchParameters searchParameters,
+            SavedSearchEntity savedSearch,
+            [Frozen] Mock<ISavedSearchRepository> savedSearchRepositoryMock,
+            [Greedy] GetUserSavedSearchQueryHandler handler)
+        {
+            // Arrange
+            savedSearch.SearchParameters = JsonConvert.SerializeObject(searchParameters);
+            savedSearchRepositoryMock.Setup(x => x.Get(query.UserReference, query.Id, CancellationToken.None))
+                .ReturnsAsync(savedSearch);
+            
+            // Act
+            var result = await handler.Handle(query, CancellationToken.None);
+            
+            // Assert
+            result.Should().NotBeNull();
+            result.SavedSearch.Should().NotBeNull();
+            result.SavedSearch.Should().BeEquivalentTo(savedSearch, options => options
+                .Excluding(x => x.SearchParameters)
+                .ExcludingMissingMembers());
+        }
+
+        [Test, MoqAutoData]
+        public async Task When_Null_Then_It_Should_Return_Null(
+            GetUserSavedSearchQuery query,
+            SavedSearchEntity savedSearch,
+            [Frozen] Mock<ISavedSearchRepository> savedSearchRepositoryMock,
+            [Greedy] GetUserSavedSearchQueryHandler handler)
+        {
+            // Arrange
+            savedSearchRepositoryMock.Setup(x => x.Get(query.UserReference, query.Id, CancellationToken.None))
+                .ReturnsAsync((SavedSearchEntity)null!);
+
+            // Act
+            var result = await handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.SavedSearch.Should().BeNull();
+        }
+    }
+}

--- a/src/SFA.DAS.FAA.Application/SavedSearches/Queries/GetSavedSearchesByUserReference/GetSavedSearchesByUserReferenceQueryHandler.cs
+++ b/src/SFA.DAS.FAA.Application/SavedSearches/Queries/GetSavedSearchesByUserReference/GetSavedSearchesByUserReferenceQueryHandler.cs
@@ -14,7 +14,9 @@ public class GetSavedSearchesByUserReferenceQueryHandler(ISavedSearchRepository 
         var results = await savedSearchRepository.GetByUserReference(request.UserReference, cancellationToken);
         return new GetSavedSearchesByUserReferenceQueryResult
         {
-            SavedSearches = results.Select(SavedSearch.From).ToList()
+            SavedSearches = results
+                .Where(x => !string.IsNullOrEmpty(x.SearchParameters))
+                .Select(SavedSearch.From).ToList()
         };
     }
 }

--- a/src/SFA.DAS.FAA.Domain/Models/SearchParameters.cs
+++ b/src/SFA.DAS.FAA.Domain/Models/SearchParameters.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace SFA.DAS.FAA.Domain.Models;
 
@@ -16,7 +16,16 @@ public record SearchParameters(
 {
     public static SearchParameters From(string source)
     {
-        return JsonConvert.DeserializeObject<SearchParameters>(source);
+        if (string.IsNullOrWhiteSpace(source))
+            return null;
+        try
+        {
+            return JsonConvert.DeserializeObject<SearchParameters>(source);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 
     public string ToJson()


### PR DESCRIPTION
✨ Add tests for handling null saved searches

- Implemented `When_SavedSearch_Is_Null_Then_NotFound_Is_Returned` test.
- Added null check in `SavedSearchDto.From` method for search parameters.
- Updated `Get` method in `UsersController` to return `NotFound` if null.
- Created `WhenHandlingGetUserSavedSearchQuery` test fixture with two tests.
- Utilized Moq for dependency setup and assertions in new tests.

Changes made by Balaji Jambulingam