### PR TITLE
FAI-2570 FAI-2571 FAI-2472 Show Foundation tags on Your applications

### DIFF
--- a/src/SFA.DAS.FAA.Api.UnitTests/Controllers/VacanciesV2/WhenGettingVacanciesByReference.cs
+++ b/src/SFA.DAS.FAA.Api.UnitTests/Controllers/VacanciesV2/WhenGettingVacanciesByReference.cs
@@ -1,17 +1,12 @@
-﻿using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
-using AutoFixture.NUnit3;
-using FluentAssertions;
-using MediatR;
+﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using Moq;
-using NUnit.Framework;
 using SFA.DAS.FAA.Api.ApiRequests;
 using SFA.DAS.FAA.Api.ApiResponses;
 using SFA.DAS.FAA.Api.Controllers;
 using SFA.DAS.FAA.Application.Vacancies.Queries.GetApprenticeshipsVacanciesByIdList;
-using SFA.DAS.Testing.AutoFixture;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace SFA.DAS.FAA.Api.UnitTests.Controllers.VacanciesV2
 {

--- a/src/SFA.DAS.FAA.Api/ApiResponses/GetApprenticeshipVacanciesByReferenceApiResponse.cs
+++ b/src/SFA.DAS.FAA.Api/ApiResponses/GetApprenticeshipVacanciesByReferenceApiResponse.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using SFA.DAS.FAA.Application.Vacancies.Queries.GetApprenticeshipsVacanciesByIdList;
+using SFA.DAS.FAA.Domain.Entities;
 
 namespace SFA.DAS.FAA.Api.ApiResponses
 {
@@ -21,6 +22,7 @@ namespace SFA.DAS.FAA.Api.ApiResponses
             public List<Address>? OtherAddresses { get; set; } = [];
             public string? EmploymentLocationInformation { get; set; }
             public string? AvailableWhere { get; set; }
+            public ApprenticeshipTypes ApprenticeshipType { get; set; }
         }
 
         public class Address
@@ -63,6 +65,7 @@ namespace SFA.DAS.FAA.Api.ApiResponses
                     IsPrimaryLocation = x.IsPrimaryLocation,
                     AvailableWhere = x.AvailableWhere,
                     EmploymentLocationInformation = x.EmploymentLocationInformation,
+                    ApprenticeshipType = x.ApprenticeshipType
                 })
             };
         }

--- a/src/SFA.DAS.FAA.Application.UnitTests/Vacancies/Queries/WhenGettingApprenticeshipVacanciesByReference.cs
+++ b/src/SFA.DAS.FAA.Application.UnitTests/Vacancies/Queries/WhenGettingApprenticeshipVacanciesByReference.cs
@@ -1,15 +1,10 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using AutoFixture.NUnit3;
-using Moq;
-using NUnit.Framework;
+﻿using SFA.DAS.FAA.Application.Vacancies.Queries.GetApprenticeshipsVacanciesByIdList;
 using SFA.DAS.FAA.Domain.Entities;
 using SFA.DAS.FAA.Domain.Interfaces;
-using SFA.DAS.Testing.AutoFixture;
-using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
-using FluentAssertions;
-using SFA.DAS.FAA.Application.Vacancies.Queries.GetApprenticeshipsVacanciesByIdList;
+using System.Threading.Tasks;
 
 namespace SFA.DAS.FAA.Application.UnitTests.Vacancies.Queries
 {
@@ -33,7 +28,8 @@ namespace SFA.DAS.FAA.Application.UnitTests.Vacancies.Queries
                 x.Title,
                 x.EmployerName,
                 x.VacancyReference,
-                x.ClosingDate
+                x.ClosingDate,
+                x.ApprenticeshipType
             }));
         }
     }

--- a/src/SFA.DAS.FAA.Application/Vacancies/Queries/GetApprenticeshipsVacanciesByIdList/GetApprenticeshipVacanciesByReferenceQuery.cs
+++ b/src/SFA.DAS.FAA.Application/Vacancies/Queries/GetApprenticeshipsVacanciesByIdList/GetApprenticeshipVacanciesByReferenceQuery.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
+using SFA.DAS.FAA.Domain.Entities;
 using SFA.DAS.FAA.Domain.Interfaces;
 
 namespace SFA.DAS.FAA.Application.Vacancies.Queries.GetApprenticeshipsVacanciesByIdList
@@ -29,6 +30,7 @@ namespace SFA.DAS.FAA.Application.Vacancies.Queries.GetApprenticeshipsVacanciesB
             public List<Address>? OtherAddresses { get; set; } = [];
             public string? EmploymentLocationInformation { get; set; }
             public string? AvailableWhere { get; set; }
+            public ApprenticeshipTypes ApprenticeshipType { get; set; }
         }
 
         public class Address
@@ -75,7 +77,8 @@ namespace SFA.DAS.FAA.Application.Vacancies.Queries.GetApprenticeshipsVacanciesB
                         OtherAddresses = x.OtherAddresses?.Select(add => (GetApprenticeshipVacanciesByReferenceQueryResult.Address)add).ToList(),
                         ApplicationUrl = x.ApplicationUrl,
                         AvailableWhere = x.AvailableWhere,
-                        EmploymentLocationInformation = x.EmploymentLocationInformation
+                        EmploymentLocationInformation = x.EmploymentLocationInformation,
+                        ApprenticeshipType = x.ApprenticeshipType ?? ApprenticeshipTypes.Standard,
                     }).ToList()
             };
         }


### PR DESCRIPTION
✨ Add ApprenticeshipType property to vacancy response/query

- Introduced `ApprenticeshipType` property to response and query classes.
- Initialized `ApprenticeshipType` in the response object mapping.
- Added default value for `ApprenticeshipType` in the query mapping.
- Included `using` directive for `SFA.DAS.FAA.Domain.Entities`.
- Ensured compatibility with the new `ApprenticeshipTypes` type.

Changes made by Balaji Jambulingam