### PR TITLE
FAI-2687 BUG Vacancy Details for NHS Jobs goes to page not found

### DIFF
--- a/src/SFA.DAS.FAA.Api.UnitTests/Controllers/VacanciesV2/WhenGettingVacancy.cs
+++ b/src/SFA.DAS.FAA.Api.UnitTests/Controllers/VacanciesV2/WhenGettingVacancy.cs
@@ -6,7 +6,6 @@ using SFA.DAS.FAA.Application.Vacancies.Queries.GetApprenticeshipVacancy;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using SFA.DAS.Common.Domain.Models;
 
 namespace SFA.DAS.FAA.Api.UnitTests.Controllers.VacanciesV2;
 public class WhenGettingVacancy
@@ -17,7 +16,7 @@ public class WhenGettingVacancy
         [Frozen] Mock<IMediator> mockMediator,
         [Greedy] VacanciesController controller)
     {
-        var vacancyReference = new VacancyReference("VAC1234");
+        var vacancyReference = new string("VAC1234");
         mockMediator
             .Setup(mediator => mediator.Send(
                 It.Is<GetApprenticeshipVacancyQuery>(query =>
@@ -39,7 +38,7 @@ public class WhenGettingVacancy
         [Frozen] Mock<IMediator> mockMediator,
         [Greedy] VacanciesController controller)
     {
-        var vacancyReference = new VacancyReference("VAC12345");
+        var vacancyReference = new string("VAC12345");
         mockMediator
             .Setup(mediator => mediator.Send(
                 It.Is<GetApprenticeshipVacancyQuery>(query =>

--- a/src/SFA.DAS.FAA.Api/ApiRequests/GetVacanciesByReferenceRequest.cs
+++ b/src/SFA.DAS.FAA.Api/ApiRequests/GetVacanciesByReferenceRequest.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Generic;
-using SFA.DAS.Common.Domain.Models;
 
 namespace SFA.DAS.FAA.Api.ApiRequests
 {
     public class GetVacanciesByReferenceRequest
     {
-        public List<VacancyReference> VacancyReferences { get; set; }
+        public List<string> VacancyReferences { get; set; }
     }
 }

--- a/src/SFA.DAS.FAA.Api/Controllers/VacanciesController.cs
+++ b/src/SFA.DAS.FAA.Api/Controllers/VacanciesController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.FAA.Api.ApiRequests;
@@ -10,8 +11,6 @@ using SFA.DAS.FAA.Domain.Models;
 using System;
 using System.Net;
 using System.Threading.Tasks;
-using Asp.Versioning;
-using SFA.DAS.Common.Domain.Models;
 
 namespace SFA.DAS.FAA.Api.Controllers
 {
@@ -23,7 +22,7 @@ namespace SFA.DAS.FAA.Api.Controllers
     {
         [HttpGet]
         [Route("{vacancyReference}")]
-        public async Task<IActionResult> Get(VacancyReference vacancyReference)
+        public async Task<IActionResult> Get(string vacancyReference)
         {
             var result = await mediator.Send(new GetApprenticeshipVacancyQuery
             {

--- a/src/SFA.DAS.FAA.Application.UnitTests/Vacancies/Queries/WhenGettingApprenticeshipVacanciesByReference.cs
+++ b/src/SFA.DAS.FAA.Application.UnitTests/Vacancies/Queries/WhenGettingApprenticeshipVacanciesByReference.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using SFA.DAS.Common.Domain.Models;
 
 namespace SFA.DAS.FAA.Application.UnitTests.Vacancies.Queries
 {
@@ -19,7 +18,7 @@ namespace SFA.DAS.FAA.Application.UnitTests.Vacancies.Queries
             [Frozen] Mock<IAzureSearchHelper> azureSearchHelper,
             GetApprenticeshipVacanciesByReferenceQueryHandler handler)
         {
-            azureSearchHelper.Setup(x => x.Get(It.Is<List<VacancyReference>>(y => y == query.VacancyReferences)))
+            azureSearchHelper.Setup(x => x.Get(It.Is<List<string>>(y => y == query.VacancyReferences)))
                 .ReturnsAsync(helperResult);
 
             var result = await handler.Handle(query, CancellationToken.None);

--- a/src/SFA.DAS.FAA.Application.UnitTests/Vacancies/Queries/WhenGettingApprenticeshipVacancy.cs
+++ b/src/SFA.DAS.FAA.Application.UnitTests/Vacancies/Queries/WhenGettingApprenticeshipVacancy.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using SFA.DAS.Common.Domain.Models;
 
 namespace SFA.DAS.FAA.Application.UnitTests.Vacancies.Queries
 {
@@ -44,7 +43,7 @@ namespace SFA.DAS.FAA.Application.UnitTests.Vacancies.Queries
                 .ReturnsAsync((ApprenticeshipVacancyItem)null);
 
             mockVacancyIndexRepository
-                .Setup(repository => repository.GetAll(It.Is<List<VacancyReference>>(refs => refs.SequenceEqual(new List<VacancyReference> { query.VacancyReference.ToShortString() }))))
+                .Setup(repository => repository.GetAll(It.Is<List<string>>(refs => refs.SequenceEqual(new List<string> { query.VacancyReference }))))
                 .ReturnsAsync(mockApprenticeshipSearchItems);
 
             // Act
@@ -66,7 +65,7 @@ namespace SFA.DAS.FAA.Application.UnitTests.Vacancies.Queries
                 .ReturnsAsync((ApprenticeshipVacancyItem)null);
 
             mockVacancyIndexRepository
-                .Setup(repository => repository.GetAll(It.Is<List<VacancyReference>>(refs => refs.SequenceEqual(new List<VacancyReference> { query.VacancyReference.ToShortString() }))))
+                .Setup(repository => repository.GetAll(It.Is<List<string>>(refs => refs.SequenceEqual(new List<string> { query.VacancyReference }))))
                 .ReturnsAsync((List<ApprenticeshipSearchItem>)null);
 
             // Act

--- a/src/SFA.DAS.FAA.Application/Vacancies/Queries/GetApprenticeshipVacancy/GetApprenticeshipVacancyQuery.cs
+++ b/src/SFA.DAS.FAA.Application/Vacancies/Queries/GetApprenticeshipVacancy/GetApprenticeshipVacancyQuery.cs
@@ -1,10 +1,9 @@
 ﻿using MediatR;
-using SFA.DAS.Common.Domain.Models;
 
 namespace SFA.DAS.FAA.Application.Vacancies.Queries.GetApprenticeshipVacancy
 {
     public class GetApprenticeshipVacancyQuery : IRequest<GetApprenticeshipVacancyResult>
     {
-        public VacancyReference VacancyReference { get; init; }
+        public string VacancyReference { get; init; }
     }
 }

--- a/src/SFA.DAS.FAA.Application/Vacancies/Queries/GetApprenticeshipsVacanciesByIdList/GetApprenticeshipVacanciesByReferenceQuery.cs
+++ b/src/SFA.DAS.FAA.Application/Vacancies/Queries/GetApprenticeshipsVacanciesByIdList/GetApprenticeshipVacanciesByReferenceQuery.cs
@@ -11,7 +11,7 @@ namespace SFA.DAS.FAA.Application.Vacancies.Queries.GetApprenticeshipsVacanciesB
 {
     public class GetApprenticeshipVacanciesByReferenceQuery : IRequest<GetApprenticeshipVacanciesByReferenceQueryResult>
     {
-        public List<Common.Domain.Models.VacancyReference> VacancyReferences { get; set; }
+        public List<string> VacancyReferences { get; set; }
     }
 
     public class GetApprenticeshipVacanciesByReferenceQueryResult

--- a/src/SFA.DAS.FAA.Data/AzureSearch/AcsVacancySearchRepository.cs
+++ b/src/SFA.DAS.FAA.Data/AzureSearch/AcsVacancySearchRepository.cs
@@ -9,7 +9,6 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using SFA.DAS.Common.Domain.Models;
 
 namespace SFA.DAS.FAA.Data.AzureSearch;
 public class AcsVacancySearchRepository(ILogger<AcsVacancySearchRepository> logger, IAzureSearchHelper searchHelper)
@@ -21,12 +20,12 @@ public class AcsVacancySearchRepository(ILogger<AcsVacancySearchRepository> logg
         return await searchHelper.Find(findVacanciesModel);
     }
 
-    public async Task<ApprenticeshipVacancyItem> Get(VacancyReference vacancyReference)
+    public async Task<ApprenticeshipVacancyItem> Get(string vacancyReference)
     {
         return await searchHelper.Get(vacancyReference);
     }
 
-    public async Task<List<ApprenticeshipSearchItem>> GetAll(List<VacancyReference> vacancyReferences)
+    public async Task<List<ApprenticeshipSearchItem>> GetAll(List<string> vacancyReferences)
     {
         return (await searchHelper.Get(vacancyReferences)).Select(vacancyItem => (ApprenticeshipSearchItem)vacancyItem).ToList();
     }

--- a/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchHelper.cs
+++ b/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchHelper.cs
@@ -15,7 +15,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
-using SFA.DAS.Common.Domain.Models;
 using SFA.DAS.FAA.Domain.Constants;
 
 namespace SFA.DAS.FAA.Data.AzureSearch;
@@ -102,11 +101,11 @@ public class AzureSearchHelper : IAzureSearchHelper
         };
     }
 
-    public async Task<ApprenticeshipVacancyItem> Get(VacancyReference vacancyReference)
+    public async Task<ApprenticeshipVacancyItem> Get(string vacancyReference)
     {
         try
         {
-            var searchResults = await _searchClient.GetDocumentAsync<SearchDocument>(vacancyReference.ToShortString());
+            var searchResults = await _searchClient.GetDocumentAsync<SearchDocument>(vacancyReference);
             return JsonSerializer.Deserialize<ApprenticeshipVacancyItem>(searchResults.Value.ToString());
         }
         catch (RequestFailedException)
@@ -115,7 +114,7 @@ public class AzureSearchHelper : IAzureSearchHelper
         }
     }
 
-    public async Task<List<ApprenticeshipSearchItem>> Get(List<VacancyReference> vacancyReferences)
+    public async Task<List<ApprenticeshipSearchItem>> Get(List<string> vacancyReferences)
     {
         var filters = new StringBuilder();
         var count = 0;
@@ -126,7 +125,7 @@ public class AzureSearchHelper : IAzureSearchHelper
                 filters.Append(" or ");
 
             count++;
-            filters.Append($"VacancyReference eq '{reference.ToString()}' and IsPrimaryLocation eq true");
+            filters.Append($"VacancyReference eq '{reference}' and IsPrimaryLocation eq true");
         }
 
         var searchOptions = new SearchOptions { Filter = filters.ToString(),QueryType = SearchQueryType.Full, Size = 500};

--- a/src/SFA.DAS.FAA.Domain/Interfaces/IAcsVacancySearchRepository.cs
+++ b/src/SFA.DAS.FAA.Domain/Interfaces/IAcsVacancySearchRepository.cs
@@ -3,14 +3,13 @@ using SFA.DAS.FAA.Domain.Entities;
 using SFA.DAS.FAA.Domain.Models;
 using System.Threading;
 using System.Threading.Tasks;
-using SFA.DAS.Common.Domain.Models;
 
 namespace SFA.DAS.FAA.Domain.Interfaces;
 public interface IAcsVacancySearchRepository
 {
     Task<ApprenticeshipSearchResponse> Find(FindVacanciesModel findVacanciesModel);
-    Task<ApprenticeshipVacancyItem> Get(VacancyReference vacancyReference);
-    Task<List<ApprenticeshipSearchItem>> GetAll(List<VacancyReference> vacancyReferences);
+    Task<ApprenticeshipVacancyItem> Get(string vacancyReference);
+    Task<List<ApprenticeshipSearchItem>> GetAll(List<string> vacancyReferences);
     Task<int> Count(FindVacanciesCountModel findVacanciesCountModel);
     Task<HealthCheckResult> GetHealthCheckStatus(CancellationToken cancellationToken);
 }

--- a/src/SFA.DAS.FAA.Domain/Interfaces/IAzureSearchHelper.cs
+++ b/src/SFA.DAS.FAA.Domain/Interfaces/IAzureSearchHelper.cs
@@ -3,14 +3,13 @@ using SFA.DAS.FAA.Domain.Models;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using SFA.DAS.Common.Domain.Models;
 
 namespace SFA.DAS.FAA.Domain.Interfaces;
 public interface IAzureSearchHelper
 {
     Task<ApprenticeshipSearchResponse> Find(FindVacanciesModel findVacanciesModel);
-    Task<ApprenticeshipVacancyItem> Get(VacancyReference vacancyReference);
+    Task<ApprenticeshipVacancyItem> Get(string vacancyReference);
     Task<int> Count(FindVacanciesCountModel countModel);
-    Task<List<ApprenticeshipSearchItem>> Get(List<VacancyReference> vacancyReferences);
+    Task<List<ApprenticeshipSearchItem>> Get(List<string> vacancyReferences);
     Task<string> GetIndexName(CancellationToken cancellationToken);
 }


### PR DESCRIPTION
✨ Refactor vacancy reference handling to use strings

- Replaced `VacancyReference` type with `string` in various classes.
- Updated `WhenGettingVacancy` tests to use `string` for vacancy references.
- Modified `GetVacanciesByReferenceRequest` to accept a list of strings.
- Adjusted `VacanciesController` and related methods to use strings.
- Updated interfaces to ensure consistency with the new string-based approach.

Changes made by Balaji Jambulingam

<img width="1912" height="511" alt="image" src="https://github.com/user-attachments/assets/3a12d080-b520-4718-be97-c6620f13ea23" />
