### PR TITLE
FAI-3329 Add flag to be able to return detailed response for search results

### DIFF
--- a/src/SFA.DAS.FAA.Api.UnitTests/ApiResponses/WhenCastingToGetSearchApprenticeshipVacanciesDetailsResponse.cs
+++ b/src/SFA.DAS.FAA.Api.UnitTests/ApiResponses/WhenCastingToGetSearchApprenticeshipVacanciesDetailsResponse.cs
@@ -1,25 +1,26 @@
-﻿using SFA.DAS.FAA.Api.ApiResponses;
+using SFA.DAS.FAA.Api.ApiResponses;
 using SFA.DAS.FAA.Application.Vacancies.Queries.SearchApprenticeshipVacancies;
-using SFA.DAS.FAA.Domain.Models;
 using System.Linq;
+using SFA.DAS.FAA.Domain.Models;
 
 namespace SFA.DAS.FAA.Api.UnitTests.ApiResponses;
 
-public class WhenCastingToGetSearchApprenticeshipVacanciesResponse
+public class WhenCastingToGetSearchApprenticeshipVacanciesDetailsResponse
 {
     [Test, AutoData]
     public void Then_Maps_Fields(SearchApprenticeshipVacanciesResult source)
     {
-        source.ApprenticeshipVacancies.ToList().ForEach(v => v.Wage = null);
-        source.ApprenticeshipVacancies.ToList().ForEach(x => x.VacancySource = nameof(DataSource.Raa));
-        var response = (GetSearchApprenticeshipVacanciesResponse)source;
+        source.ApprenticeshipVacanciesWithDetails.ToList().ForEach(v => v.Wage = null);
+        source.ApprenticeshipVacanciesWithDetails.ToList().ForEach(x => x.VacancySource = nameof(DataSource.Raa));
+        
+        var response = (GetSearchApprenticeshipVacanciesDetailsResponse)source;
 
         response.TotalFound.Should().Be(source.TotalFound);
         response.Total.Should().Be(source.Total);
         response.Should().BeEquivalentTo(source, options => options
             .Excluding(c => c.ApprenticeshipVacancies)
             .Excluding(c=>c.ApprenticeshipVacanciesWithDetails));
-        response.ApprenticeshipVacancies.Should().BeEquivalentTo(source.ApprenticeshipVacancies, options => options
+        response.ApprenticeshipVacancies.Should().BeEquivalentTo(source.ApprenticeshipVacanciesWithDetails, options => options
             .ExcludingMissingMembers());
     }
 }

--- a/src/SFA.DAS.FAA.Api.UnitTests/Controllers/VacanciesV2/WhenGettingVacancySearch.cs
+++ b/src/SFA.DAS.FAA.Api.UnitTests/Controllers/VacanciesV2/WhenGettingVacancySearch.cs
@@ -42,7 +42,8 @@ public class WhenGettingVacancySearch
                     query.VacancySort.Equals(request.Sort) &&
 					query.SearchTerm == request.SearchTerm &&
                     query.AdditionalDataSources == request.AdditionalDataSources &&
-                    query.OnlyPrimaryLocations == request.OnlyPrimaryLocations
+                    query.OnlyPrimaryLocations == request.OnlyPrimaryLocations &&
+                    query.IncludeDetails == request.IncludeDetails
                 ),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(mediatorResult);

--- a/src/SFA.DAS.FAA.Api.UnitTests/Controllers/VacanciesV2/WhenGettingVacancySearch.cs
+++ b/src/SFA.DAS.FAA.Api.UnitTests/Controllers/VacanciesV2/WhenGettingVacancySearch.cs
@@ -20,6 +20,7 @@ public class WhenGettingVacancySearch
     [Greedy] VacanciesController controller)
     {
         request.Sort = VacancySort.DistanceDesc;
+        request.IncludeDetails = false;
         mockMediator
             .Setup(mediator => mediator.Send(
                 It.Is<SearchApprenticeshipVacanciesQuery>(query =>
@@ -44,6 +45,50 @@ public class WhenGettingVacancySearch
                     query.OnlyPrimaryLocations == request.OnlyPrimaryLocations
                 ),
                 It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mediatorResult);
+
+        var result = await controller.Search(request) as OkObjectResult;
+
+        result.Should().NotBeNull();
+        result?.StatusCode.Should().Be((int)HttpStatusCode.OK);
+        var apiModel = result?.Value as GetSearchApprenticeshipVacanciesResponse;
+        apiModel.Should().NotBeNull();
+        apiModel.Should().BeEquivalentTo((GetSearchApprenticeshipVacanciesResponse)mediatorResult);
+    }
+
+    [Test, MoqAutoData]
+    public async Task Then_Returns_Details_Response_When_IncludeDetails_Is_True_And_PageSize_Is_Within_Limit(
+        SearchVacancyRequest request,
+        SearchApprenticeshipVacanciesResult mediatorResult,
+        [Frozen] Mock<IMediator> mockMediator,
+        [Greedy] VacanciesController controller)
+    {
+        request.IncludeDetails = true;
+        request.PageSize = 10;
+        mockMediator
+            .Setup(mediator => mediator.Send(It.IsAny<SearchApprenticeshipVacanciesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mediatorResult);
+
+        var result = await controller.Search(request) as OkObjectResult;
+
+        result.Should().NotBeNull();
+        result?.StatusCode.Should().Be((int)HttpStatusCode.OK);
+        var apiModel = result?.Value as GetSearchApprenticeshipVacanciesDetailsResponse;
+        apiModel.Should().NotBeNull();
+        apiModel.Should().BeEquivalentTo((GetSearchApprenticeshipVacanciesDetailsResponse)mediatorResult);
+    }
+
+    [Test, MoqAutoData]
+    public async Task Then_Returns_Standard_Response_When_IncludeDetails_Is_True_But_PageSize_Exceeds_Limit(
+        SearchVacancyRequest request,
+        SearchApprenticeshipVacanciesResult mediatorResult,
+        [Frozen] Mock<IMediator> mockMediator,
+        [Greedy] VacanciesController controller)
+    {
+        request.IncludeDetails = true;
+        request.PageSize = 101;
+        mockMediator
+            .Setup(mediator => mediator.Send(It.IsAny<SearchApprenticeshipVacanciesQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(mediatorResult);
 
         var result = await controller.Search(request) as OkObjectResult;

--- a/src/SFA.DAS.FAA.Api.UnitTests/SFA.DAS.FAA.Api.UnitTests.csproj
+++ b/src/SFA.DAS.FAA.Api.UnitTests/SFA.DAS.FAA.Api.UnitTests.csproj
@@ -6,16 +6,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="8.0.0">
+        <PackageReference Include="coverlet.msbuild" Version="8.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="7.2.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-        <PackageReference Include="NUnit" Version="4.5.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+        <PackageReference Include="FluentAssertions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageReference Include="NUnit" Version="4.5.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="SFA.DAS.Testing.AutoFixture" Version="17.1.165" />
-        <PackageReference Include="coverlet.collector" Version="8.0.0">
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/SFA.DAS.FAA.Api.UnitTests/SFA.DAS.FAA.Api.UnitTests.csproj
+++ b/src/SFA.DAS.FAA.Api.UnitTests/SFA.DAS.FAA.Api.UnitTests.csproj
@@ -10,7 +10,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="8.0.0" />
+        <PackageReference Include="FluentAssertions" Version="7.2.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="NUnit" Version="4.5.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />

--- a/src/SFA.DAS.FAA.Api/ApiRequests/SearchVacancyRequest.cs
+++ b/src/SFA.DAS.FAA.Api/ApiRequests/SearchVacancyRequest.cs
@@ -53,4 +53,6 @@ public class SearchVacancyRequest
     public List<ApprenticeshipTypes> ApprenticeshipTypes { get; set; } = null;
     [FromQuery]
     public bool OnlyPrimaryLocations { get; set; }
+    [FromQuery] 
+    public bool IncludeDetails { get; set; } = false;
 }

--- a/src/SFA.DAS.FAA.Api/ApiResponses/GetSearchApprenticeshipVacanciesDetailsResponse.cs
+++ b/src/SFA.DAS.FAA.Api/ApiResponses/GetSearchApprenticeshipVacanciesDetailsResponse.cs
@@ -14,7 +14,7 @@ public class GetSearchApprenticeshipVacanciesDetailsResponse
     {
         return new GetSearchApprenticeshipVacanciesDetailsResponse
         {
-            ApprenticeshipVacancies = source.ApprenticeshipVacancies.Select(item => (GetApprenticeshipVacancyDetailResponse)item),
+            ApprenticeshipVacancies = source.ApprenticeshipVacanciesWithDetails.Select(GetApprenticeshipVacancyDetailResponse.From),
             TotalFound = source.TotalFound,
             Total = source.Total
         };

--- a/src/SFA.DAS.FAA.Api/ApiResponses/GetSearchApprenticeshipVacanciesDetailsResponse.cs
+++ b/src/SFA.DAS.FAA.Api/ApiResponses/GetSearchApprenticeshipVacanciesDetailsResponse.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Linq;
+using SFA.DAS.FAA.Application.Vacancies.Queries.SearchApprenticeshipVacancies;
+
+namespace SFA.DAS.FAA.Api.ApiResponses;
+
+public class GetSearchApprenticeshipVacanciesDetailsResponse
+{
+    public int Total { get; set; }
+    public int TotalFound { get; set; }
+    public IEnumerable<GetApprenticeshipVacancyDetailResponse> ApprenticeshipVacancies { get; set; }
+
+    public static implicit operator GetSearchApprenticeshipVacanciesDetailsResponse(SearchApprenticeshipVacanciesResult source)
+    {
+        return new GetSearchApprenticeshipVacanciesDetailsResponse
+        {
+            ApprenticeshipVacancies = source.ApprenticeshipVacancies.Select(item => (GetApprenticeshipVacancyDetailResponse)item),
+            TotalFound = source.TotalFound,
+            Total = source.Total
+        };
+    }
+}

--- a/src/SFA.DAS.FAA.Api/AppStart/AddAzureSearchClientExtensions.cs
+++ b/src/SFA.DAS.FAA.Api/AppStart/AddAzureSearchClientExtensions.cs
@@ -16,7 +16,7 @@ namespace SFA.DAS.FAA.Api.AppStart;
 
 public static class AddAzureSearchClientExtensions
 {
-    public static void AddAzureSearchClient(this IServiceCollection services)
+    public static void AddAzureSearchClient(this IServiceCollection services, bool isLocal)
     {
         services.AddSingleton<TokenCredential>(_ =>
         {
@@ -24,8 +24,26 @@ public static class AddAzureSearchClientExtensions
             var networkTimeout = TimeSpan.FromSeconds(1);
             var delay = TimeSpan.FromMilliseconds(100);
 
+            if (isLocal)
+            {
+                return new ChainedTokenCredential(
+                    new AzureCliCredential(new AzureCliCredentialOptions
+                    {
+                        Retry = { NetworkTimeout = networkTimeout, MaxRetries = maxRetries, Delay = delay }
+                    }),
+                    new VisualStudioCredential(new VisualStudioCredentialOptions
+                    {
+                        Retry = { NetworkTimeout = networkTimeout, MaxRetries = maxRetries, Delay = delay }
+                    }),
+                    new VisualStudioCodeCredential(new VisualStudioCodeCredentialOptions
+                    {
+                        Retry = { NetworkTimeout = networkTimeout, MaxRetries = maxRetries, Delay = delay }
+                    })
+                );
+            }
+
             return new ChainedTokenCredential(
-                new ManagedIdentityCredential(options: new TokenCredentialOptions
+                new ManagedIdentityCredential(options: new ManagedIdentityCredentialOptions
                 {
                     Retry = { NetworkTimeout = networkTimeout, MaxRetries = maxRetries, Delay = delay }
                 }),
@@ -42,6 +60,7 @@ public static class AddAzureSearchClientExtensions
                     Retry = { NetworkTimeout = networkTimeout, MaxRetries = maxRetries, Delay = delay }
                 })
             );
+
         });
 
         services.AddSingleton<SearchClient>(sp =>

--- a/src/SFA.DAS.FAA.Api/Controllers/VacanciesController.cs
+++ b/src/SFA.DAS.FAA.Api/Controllers/VacanciesController.cs
@@ -80,11 +80,15 @@ public class VacanciesController(IMediator mediator) : ControllerBase
                 StandardLarsCode = request.StandardLarsCode,
                 Ukprn = request.Ukprn,
                 VacancySort = request.Sort ?? VacancySort.AgeDesc,
-                OnlyPrimaryLocations = request.OnlyPrimaryLocations
+                OnlyPrimaryLocations = request.OnlyPrimaryLocations,
             });
 
-            var apiResponse = (GetSearchApprenticeshipVacanciesResponse)result;
-            return Ok(apiResponse);
+            if (request.IncludeDetails && request.PageSize <= 100)
+            {
+                return Ok((GetSearchApprenticeshipVacanciesDetailsResponse)result);    
+            }
+            
+            return Ok((GetSearchApprenticeshipVacanciesResponse)result);
         }
         catch (Exception ex)
         {

--- a/src/SFA.DAS.FAA.Api/Controllers/VacanciesController.cs
+++ b/src/SFA.DAS.FAA.Api/Controllers/VacanciesController.cs
@@ -81,6 +81,7 @@ public class VacanciesController(IMediator mediator) : ControllerBase
                 Ukprn = request.Ukprn,
                 VacancySort = request.Sort ?? VacancySort.AgeDesc,
                 OnlyPrimaryLocations = request.OnlyPrimaryLocations,
+                IncludeDetails = request.IncludeDetails
             });
 
             if (request.IncludeDetails && request.PageSize <= 100)

--- a/src/SFA.DAS.FAA.Api/SFA.DAS.FAA.Api.csproj
+++ b/src/SFA.DAS.FAA.Api/SFA.DAS.FAA.Api.csproj
@@ -6,18 +6,18 @@
 		<PackageReference Include="Asp.Versioning.Mvc" Version="8.1.1" />
 		<PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
 		<PackageReference Include="MediatR" Version="12.5.0" />
-		<PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="10.0.3" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
+		<PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="10.0.5" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
 		<PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.3" />
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.3" />
-		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.5" />
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.0" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.5" />
 		<PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="17.1.165" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\SFA.DAS.FAA.Application\SFA.DAS.FAA.Application.csproj" />

--- a/src/SFA.DAS.FAA.Api/Startup.cs
+++ b/src/SFA.DAS.FAA.Api/Startup.cs
@@ -77,7 +77,7 @@ public class Startup
             .GetSection("FindApprenticeshipsApi")
             .Get<FindApprenticeshipsApiConfiguration>();
 
-        services.AddAzureSearchClient();
+        services.AddAzureSearchClient(_configuration["ResourceEnvironmentName"] == "LOCAL");
         services.AddDatabaseRegistration(findApprenticeshipsApiConfiguration!, _configuration["Environment"]);
 
         if (!ConfigurationIsLocalOrDev())

--- a/src/SFA.DAS.FAA.Api/appsettings.json
+++ b/src/SFA.DAS.FAA.Api/appsettings.json
@@ -7,6 +7,7 @@
   "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true;",
   "ConfigNames": "SFA.DAS.FindApprenticeships.Api",
   "Environment": "LOCAL",
+  "ResourceEnvironmentName": "LOCAL",
   "Version": "1.0",
   "APPINSIGHTS_INSTRUMENTATIONKEY": "",
   "AllowedHosts": "*"

--- a/src/SFA.DAS.FAA.Application.UnitTests/SFA.DAS.FAA.Application.UnitTests.csproj
+++ b/src/SFA.DAS.FAA.Application.UnitTests/SFA.DAS.FAA.Application.UnitTests.csproj
@@ -6,14 +6,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="8.0.0">
+        <PackageReference Include="coverlet.msbuild" Version="8.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="7.2.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-        <PackageReference Include="NUnit" Version="4.5.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+        <PackageReference Include="FluentAssertions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageReference Include="NUnit" Version="4.5.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="SFA.DAS.Testing.AutoFixture" Version="17.1.165" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     </ItemGroup>

--- a/src/SFA.DAS.FAA.Application.UnitTests/SFA.DAS.FAA.Application.UnitTests.csproj
+++ b/src/SFA.DAS.FAA.Application.UnitTests/SFA.DAS.FAA.Application.UnitTests.csproj
@@ -10,7 +10,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="8.0.0" />
+        <PackageReference Include="FluentAssertions" Version="7.2.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="NUnit" Version="4.5.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />

--- a/src/SFA.DAS.FAA.Application.UnitTests/Vacancies/Queries/WhenSearchingApprenticeshipVacancies.cs
+++ b/src/SFA.DAS.FAA.Application.UnitTests/Vacancies/Queries/WhenSearchingApprenticeshipVacancies.cs
@@ -36,7 +36,8 @@ public class WhenSearchingApprenticeshipVacancies
                 c.SearchTerm.Equals(query.SearchTerm) &&
                 c.DisabilityConfident.Equals(query.DisabilityConfident) &&
                 c.AdditionalDataSources.Equals(query.AdditionalDataSources) &&
-                c.OnlyPrimaryLocations.Equals(query.OnlyPrimaryLocations)
+                c.OnlyPrimaryLocations.Equals(query.OnlyPrimaryLocations) &&
+                c.IncludeDetails.Equals(query.IncludeDetails)
             )))
             .ReturnsAsync(responseFromRepository);
 
@@ -44,6 +45,8 @@ public class WhenSearchingApprenticeshipVacancies
 
         result.ApprenticeshipVacancies
             .Should().BeEquivalentTo(responseFromRepository.ApprenticeshipVacancies);
+        result.ApprenticeshipVacanciesWithDetails
+            .Should().BeEquivalentTo(responseFromRepository.ApprenticeshipVacanciesWithDetails);
         result.TotalFound.Should().Be(responseFromRepository.TotalFound);
         result.Total.Should().Be(responseFromRepository.Total);
     }

--- a/src/SFA.DAS.FAA.Application/SFA.DAS.FAA.Application.csproj
+++ b/src/SFA.DAS.FAA.Application/SFA.DAS.FAA.Application.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
       <PackageReference Include="MediatR" Version="12.5.0" />
-      <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="10.0.3" />
+      <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="10.0.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SFA.DAS.FAA.Application/Vacancies/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesQuery.cs
+++ b/src/SFA.DAS.FAA.Application/Vacancies/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesQuery.cs
@@ -29,4 +29,5 @@ public class SearchApprenticeshipVacanciesQuery : IRequest<SearchApprenticeshipV
     public List<DataSource> AdditionalDataSources { get; set; }
     public List<ApprenticeshipTypes> ApprenticeshipTypes { get; set; }
     public bool OnlyPrimaryLocations { get; set; }
+    public bool IncludeDetails { get; set; }
 }

--- a/src/SFA.DAS.FAA.Application/Vacancies/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesQueryHandler.cs
+++ b/src/SFA.DAS.FAA.Application/Vacancies/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesQueryHandler.cs
@@ -34,7 +34,8 @@ public class SearchApprenticeshipVacanciesQueryHandler(IAcsVacancySearchReposito
             StandardLarsCode = request.StandardLarsCode,
             Ukprn = request.Ukprn,
             VacancySort = request.VacancySort,
-            OnlyPrimaryLocations = request.OnlyPrimaryLocations
+            OnlyPrimaryLocations = request.OnlyPrimaryLocations,
+            IncludeDetails = request.IncludeDetails
         };
 
         var searchResult = await acsVacancySearchRepository.Find(model);
@@ -42,6 +43,7 @@ public class SearchApprenticeshipVacanciesQueryHandler(IAcsVacancySearchReposito
         return new SearchApprenticeshipVacanciesResult
         {
             ApprenticeshipVacancies = searchResult.ApprenticeshipVacancies,
+            ApprenticeshipVacanciesWithDetails = searchResult.ApprenticeshipVacanciesWithDetails,
             TotalFound = searchResult.TotalFound,
             Total = searchResult.Total
         };

--- a/src/SFA.DAS.FAA.Application/Vacancies/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesResult.cs
+++ b/src/SFA.DAS.FAA.Application/Vacancies/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesResult.cs
@@ -6,6 +6,7 @@ namespace SFA.DAS.FAA.Application.Vacancies.Queries.SearchApprenticeshipVacancie
 public class SearchApprenticeshipVacanciesResult
 {
     public IEnumerable<ApprenticeshipSearchItem> ApprenticeshipVacancies { get; set; }
+    public IEnumerable<ApprenticeshipVacancyItem> ApprenticeshipVacanciesWithDetails { get; set; }
     public int TotalFound { get; set; }
     public int Total { get; set; }
 }

--- a/src/SFA.DAS.FAA.Data.UnitTests/AzureSearch/AzureSearchHelperTests.cs
+++ b/src/SFA.DAS.FAA.Data.UnitTests/AzureSearch/AzureSearchHelperTests.cs
@@ -1,0 +1,70 @@
+using Azure;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Indexes;
+using Azure.Search.Documents.Models;
+using Moq;
+using SFA.DAS.FAA.Data.AzureSearch;
+using SFA.DAS.FAA.Domain.Entities;
+using SFA.DAS.FAA.Domain.Models;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.FAA.Data.UnitTests.AzureSearch;
+
+public class AzureSearchHelperTests
+{
+    private Mock<SearchClient> _searchClient;
+    private Mock<SearchIndexClient> _searchIndexClient;
+    private AzureSearchHelper _helper;
+
+    [SetUp]
+    public void Setup()
+    {
+        _searchClient = new Mock<SearchClient>();
+        _searchIndexClient = new Mock<SearchIndexClient>();
+        _helper = new AzureSearchHelper(_searchClient.Object, _searchIndexClient.Object);
+    }
+
+    [Test, AutoData]
+    public async Task Find_When_IncludeDetails_Is_False_Returns_ApprenticeshipVacancies(FindVacanciesModel model)
+    {
+        model = model with { IncludeDetails = false };
+        var searchDocument = new SearchDocument(new Dictionary<string, object> { { "Id", "1" }, { "VacancyReference", "123" } });
+        
+        var mockSearchResults = SearchModelFactory.SearchResults(
+            [SearchModelFactory.SearchResult(searchDocument, null, null)],
+            1, null, null, new Mock<Response>().Object);
+
+        _searchClient.Setup(x => x.SearchAsync<SearchDocument>(It.IsAny<string>(), It.IsAny<SearchOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(mockSearchResults, new Mock<Response>().Object));
+
+        var result = await _helper.Find(model);
+
+        result.ApprenticeshipVacancies.Should().NotBeEmpty();
+        result.ApprenticeshipVacanciesWithDetails.Should().BeEmpty();
+        result.TotalFound.Should().Be(1);
+    }
+
+    [Test, AutoData]
+    public async Task Find_When_IncludeDetails_Is_True_And_PageSize_Less_Than_Or_Equal_To_One_Hundred_Returns_ApprenticeshipVacanciesWithDetails(FindVacanciesModel model)
+    {
+        model = model with { IncludeDetails = true, PageSize = 10 };
+        var searchDocument = new SearchDocument(new Dictionary<string, object> { { "Id", "1" }, { "VacancyReference", "123" } });
+        
+        var mockSearchResults = SearchModelFactory.SearchResults(
+            [SearchModelFactory.SearchResult(searchDocument, null, null)],
+            1, null, null, new Mock<Response>().Object);
+
+        _searchClient.Setup(x => x.SearchAsync<SearchDocument>(It.IsAny<string>(), It.IsAny<SearchOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(mockSearchResults, new Mock<Response>().Object));
+
+        var result = await _helper.Find(model);
+
+        result.ApprenticeshipVacancies.Should().BeEmpty();
+        result.ApprenticeshipVacanciesWithDetails.Should().NotBeEmpty();
+        result.TotalFound.Should().Be(1);
+    }
+}

--- a/src/SFA.DAS.FAA.Data.UnitTests/SFA.DAS.FAA.Data.UnitTests.csproj
+++ b/src/SFA.DAS.FAA.Data.UnitTests/SFA.DAS.FAA.Data.UnitTests.csproj
@@ -10,7 +10,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="8.0.0" />
+        <PackageReference Include="FluentAssertions" Version="7.2.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="NUnit" Version="4.5.1" />

--- a/src/SFA.DAS.FAA.Data.UnitTests/SFA.DAS.FAA.Data.UnitTests.csproj
+++ b/src/SFA.DAS.FAA.Data.UnitTests/SFA.DAS.FAA.Data.UnitTests.csproj
@@ -6,15 +6,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="8.0.0">
+        <PackageReference Include="coverlet.msbuild" Version="8.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="7.2.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="FluentAssertions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NUnit" Version="4.5.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+        <PackageReference Include="NUnit" Version="4.5.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="SFA.DAS.Testing.AutoFixture" Version="17.1.165" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     </ItemGroup>

--- a/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchHelper.cs
+++ b/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchHelper.cs
@@ -42,17 +42,24 @@ public class AzureSearchHelper(SearchClient searchClient,
 
         var searchResults = searchResultsTask.Result;
         var totalVacanciesCount = totalVacanciesCountTask.Result;
-        var result = searchResults.Value.GetResults().ToList().Select(searchResult => JsonSerializer.Deserialize<ApprenticeshipSearchItem>(searchResult.Document.ToString())).ToList();
+        var result = !findVacanciesModel.IncludeDetails ? searchResults.Value.GetResults().ToList().Select(searchResult => JsonSerializer.Deserialize<ApprenticeshipSearchItem>(searchResult.Document.ToString())).ToList() : [];
 
+        var detailsResult = findVacanciesModel.IncludeDetails && findVacanciesModel.PageSize <= 100
+            ? searchResults.Value.GetResults().ToList().Select(searchResult =>
+                JsonSerializer.Deserialize<ApprenticeshipVacancyItem>(searchResult.Document.ToString())).ToList()
+            : [];
+        
         if (findVacanciesModel.Lat.HasValue && findVacanciesModel.Lon.HasValue)
         {
             result.ForEach(c => c.SearchGeoPoint = new GeoPoint { Lat = findVacanciesModel.Lat.Value, Lon = findVacanciesModel.Lon.Value });
+            detailsResult.ForEach(c => c.SearchGeoPoint = new GeoPoint { Lat = findVacanciesModel.Lat.Value, Lon = findVacanciesModel.Lon.Value });
         }
 
         return new ApprenticeshipSearchResponse
         {
             ApprenticeshipVacancies = result.Select(c => c)
                 .ToList(),
+            ApprenticeshipVacanciesWithDetails = detailsResult.Select(c => c).ToList(),
             TotalFound = Convert.ToInt32(searchResults.Value.TotalCount),
             Total = Convert.ToInt32(totalVacanciesCount.Value.TotalCount)
         };

--- a/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchHelper.cs
+++ b/src/SFA.DAS.FAA.Data/AzureSearch/AzureSearchHelper.cs
@@ -42,12 +42,13 @@ public class AzureSearchHelper(SearchClient searchClient,
 
         var searchResults = searchResultsTask.Result;
         var totalVacanciesCount = totalVacanciesCountTask.Result;
-        var result = !findVacanciesModel.IncludeDetails ? searchResults.Value.GetResults().ToList().Select(searchResult => JsonSerializer.Deserialize<ApprenticeshipSearchItem>(searchResult.Document.ToString())).ToList() : [];
-
+        
         var detailsResult = findVacanciesModel.IncludeDetails && findVacanciesModel.PageSize <= 100
             ? searchResults.Value.GetResults().ToList().Select(searchResult =>
                 JsonSerializer.Deserialize<ApprenticeshipVacancyItem>(searchResult.Document.ToString())).ToList()
             : [];
+        
+        var result = detailsResult.Count == 0 ? searchResults.Value.GetResults().ToList().Select(searchResult => JsonSerializer.Deserialize<ApprenticeshipSearchItem>(searchResult.Document.ToString())).ToList() : [];
         
         if (findVacanciesModel.Lat.HasValue && findVacanciesModel.Lon.HasValue)
         {

--- a/src/SFA.DAS.FAA.Data/SFA.DAS.FAA.Data.csproj
+++ b/src/SFA.DAS.FAA.Data/SFA.DAS.FAA.Data.csproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>
       <PackageReference Include="Azure.Identity" Version="1.20.0" />
-      <PackageReference Include="Azure.Search.Documents" Version="11.7.0" />
+      <PackageReference Include="Azure.Search.Documents" Version="11.8.0-beta.1" />
       <PackageReference Include="Microsoft.Azure.Core.Spatial" Version="1.1.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
       <PackageReference Include="Microsoft.Spatial" Version="8.4.3" />

--- a/src/SFA.DAS.FAA.Data/SFA.DAS.FAA.Data.csproj
+++ b/src/SFA.DAS.FAA.Data/SFA.DAS.FAA.Data.csproj
@@ -13,20 +13,20 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Azure.Identity" Version="1.18.0" />
-      <PackageReference Include="Azure.Search.Documents" Version="11.5.0-beta.5" />
+      <PackageReference Include="Azure.Identity" Version="1.20.0" />
+      <PackageReference Include="Azure.Search.Documents" Version="11.7.0" />
       <PackageReference Include="Microsoft.Azure.Core.Spatial" Version="1.1.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
       <PackageReference Include="Microsoft.Spatial" Version="8.4.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
       <PackageReference Include="SFA.DAS.Api.Common" Version="17.1.165" />
-      <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="10.0.3" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
-      <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.0.1" />
-      <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.0.1" />
-      <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
-      <PackageReference Include="System.Text.Json" Version="10.0.3" />
+      <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="10.0.5" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+      <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.17.0" />
+      <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.17.0" />
+      <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
+      <PackageReference Include="System.Text.Json" Version="10.0.5" />
     </ItemGroup>
 
 </Project>

--- a/src/SFA.DAS.FAA.Domain.UnitTests/SFA.DAS.FAA.Domain.UnitTests.csproj
+++ b/src/SFA.DAS.FAA.Domain.UnitTests/SFA.DAS.FAA.Domain.UnitTests.csproj
@@ -10,7 +10,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="8.0.0" />
+		<PackageReference Include="FluentAssertions" Version="7.2.2" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
 		<PackageReference Include="NUnit" Version="4.5.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />

--- a/src/SFA.DAS.FAA.Domain.UnitTests/SFA.DAS.FAA.Domain.UnitTests.csproj
+++ b/src/SFA.DAS.FAA.Domain.UnitTests/SFA.DAS.FAA.Domain.UnitTests.csproj
@@ -6,14 +6,14 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.msbuild" Version="8.0.0">
+		<PackageReference Include="coverlet.msbuild" Version="8.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="7.2.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-		<PackageReference Include="NUnit" Version="4.5.0" />
-		<PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+		<PackageReference Include="FluentAssertions" Version="8.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+		<PackageReference Include="NUnit" Version="4.5.1" />
+		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="SFA.DAS.Testing.AutoFixture" Version="17.1.165" />
 		<PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
 	</ItemGroup>

--- a/src/SFA.DAS.FAA.Domain/Entities/ApprenticeshipSearchResponse.cs
+++ b/src/SFA.DAS.FAA.Domain/Entities/ApprenticeshipSearchResponse.cs
@@ -5,6 +5,7 @@ namespace SFA.DAS.FAA.Domain.Entities;
 public class ApprenticeshipSearchResponse
 {
     public List<ApprenticeshipSearchItem> ApprenticeshipVacancies { get; set; } = new List<ApprenticeshipSearchItem>();
+    public List<ApprenticeshipVacancyItem> ApprenticeshipVacanciesWithDetails { get; set; } = new List<ApprenticeshipVacancyItem>();
     public int TotalFound { get; set; }
     public int Total { get; set; }
 }

--- a/src/SFA.DAS.FAA.Domain/Models/FindVacanciesCountModel.cs
+++ b/src/SFA.DAS.FAA.Domain/Models/FindVacanciesCountModel.cs
@@ -3,7 +3,7 @@ using SFA.DAS.FAA.Domain.Entities;
 
 namespace SFA.DAS.FAA.Domain.Models;
 
-public class FindVacanciesCountModel : FindFilteredVacanciesModel
+public record FindVacanciesCountModel : FindFilteredVacanciesModel
 {
     public string? SearchTerm { get; init; }
     public int? Ukprn { get; init; }

--- a/src/SFA.DAS.FAA.Domain/Models/FindVacanciesModel.cs
+++ b/src/SFA.DAS.FAA.Domain/Models/FindVacanciesModel.cs
@@ -3,7 +3,7 @@ using SFA.DAS.FAA.Domain.Entities;
 
 namespace SFA.DAS.FAA.Domain.Models;
 
-public class FindVacanciesModel : FindFilteredVacanciesModel
+public record FindVacanciesModel : FindFilteredVacanciesModel
 {
     public string? SearchTerm { get; init; }
     public int PageNumber { get; set; }
@@ -23,9 +23,10 @@ public class FindVacanciesModel : FindFilteredVacanciesModel
     public List<DataSource> AdditionalDataSources { get; set; }
     public List<ApprenticeshipTypes> ApprenticeshipTypes { get; set; }
     public bool OnlyPrimaryLocations { get; set; }
+    public bool IncludeDetails { get; set; }
 }
 
-public class FindFilteredVacanciesModel
+public record FindFilteredVacanciesModel
 {
     public double? Lat { get; set; }
     public double? Lon { get; set; }

--- a/src/SFA.DAS.FAA.Domain/SFA.DAS.FAA.Domain.csproj
+++ b/src/SFA.DAS.FAA.Domain/SFA.DAS.FAA.Domain.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
       <PackageReference Include="Azure.Core" Version="1.52.0" />
-      <PackageReference Include="Azure.Search.Documents" Version="11.7.0" />
+      <PackageReference Include="Azure.Search.Documents" Version="11.8.0-beta.1" />
       <PackageReference Include="Microsoft.Azure.Search.Data" Version="10.1.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
       <PackageReference Include="SFA.DAS.Common.Domain" Version="1.4.308" />

--- a/src/SFA.DAS.FAA.Domain/SFA.DAS.FAA.Domain.csproj
+++ b/src/SFA.DAS.FAA.Domain/SFA.DAS.FAA.Domain.csproj
@@ -5,10 +5,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Azure.Core" Version="1.50.0" />
-      <PackageReference Include="Azure.Search.Documents" Version="11.5.0-beta.5" />
+      <PackageReference Include="Azure.Core" Version="1.52.0" />
+      <PackageReference Include="Azure.Search.Documents" Version="11.7.0" />
       <PackageReference Include="Microsoft.Azure.Search.Data" Version="10.1.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
       <PackageReference Include="SFA.DAS.Common.Domain" Version="1.4.308" />
     </ItemGroup>
 


### PR DESCRIPTION
This means that all the fields for a vacancy will be returned if `IncludeDetails` is passed in the query string and the page size is 100 or less